### PR TITLE
Add alt text for gallery carousel images

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,14 +225,14 @@
   </section>
 
   <section class="gallery-carousel">
-    <img src="dogs/dog1.jpg">
-    <img src="dogs/dog2.jpg">
-    <img src="dogs/dog3.jpg">
-    <img src="dogs/dog4.jpg">
-    <img src="dogs/dog5.jpg">
-    <img src="dogs/dog6.jpg">
-    <img src="dogs/dog7.jpg">
-    <img src="dogs/dog8.jpg">
+    <img src="dogs/dog1.jpg" alt="Καλλωπισμένος σκύλος 1">
+    <img src="dogs/dog2.jpg" alt="Καλλωπισμένος σκύλος 2">
+    <img src="dogs/dog3.jpg" alt="Καλλωπισμένος σκύλος 3">
+    <img src="dogs/dog4.jpg" alt="Καλλωπισμένος σκύλος 4">
+    <img src="dogs/dog5.jpg" alt="Καλλωπισμένος σκύλος 5">
+    <img src="dogs/dog6.jpg" alt="Καλλωπισμένος σκύλος 6">
+    <img src="dogs/dog7.jpg" alt="Καλλωπισμένος σκύλος 7">
+    <img src="dogs/dog8.jpg" alt="Καλλωπισμένος σκύλος 8">
   </section>
 
   <section class="faq">


### PR DESCRIPTION
## Summary
- add descriptive alt attributes to gallery carousel images for accessibility

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a1f34e3f1c83208d80201954981cde