### PR TITLE
Use contain background for hero image

### DIFF
--- a/style.css
+++ b/style.css
@@ -36,10 +36,12 @@ h1, h2 {
   color: var(--accent);
 }
 .hero {
-  background: url('Pawsh pet salon/Pawsh pet salon 24.jpg') no-repeat center center;
-  background-size: cover;
+  background: url('Pawsh pet salon/Pawsh pet salon 24.jpg');
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
   text-align: center;
-  padding: 6rem 1rem;
+  padding: 4rem 1rem;
   color: white;
 }
 .hero h1,


### PR DESCRIPTION
## Summary
- Switch hero section background scaling to `contain` so full image is shown
- Center hero background and prevent tiling
- Tweak hero padding for better balance with new background size

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a22311f5e48320ad98a424682886b0