### PR TITLE
Make hero images full width and taller

### DIFF
--- a/style.css
+++ b/style.css
@@ -37,12 +37,20 @@ h1, h2 {
 }
 .hero {
   background: url('Pawsh pet salon/Pawsh pet salon 24.jpg');
-  background-size: contain;
+  background-size: cover;
   background-repeat: no-repeat;
   background-position: center;
   text-align: center;
   padding: 4rem 1rem;
   color: white;
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  min-height: 600px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 }
 .hero h1,
 .hero p {


### PR DESCRIPTION
## Summary
- Ensure hero section spans full screen width and uses cover scaling for background images.
- Increase hero section height and center its content for a larger visual impact.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2362e12648320a6246804b2de4966