### PR TITLE
Limit hero images width to match header

### DIFF
--- a/style.css
+++ b/style.css
@@ -43,9 +43,9 @@ h1, h2 {
   text-align: center;
   padding: 4rem 1rem;
   color: white;
+  max-width: 960px;
   width: 100%;
-  max-width: none;
-  margin: 0;
+  margin: 0 auto;
   min-height: 600px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- constrain hero section to the header's width so hero images no longer extend past it on desktop and mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a243931cf083208088bc5abc7d3f82