### PR TITLE
Add bubble decorations to hero section

### DIFF
--- a/bubbles.svg
+++ b/bubbles.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="300" viewBox="0 0 80 300">
+  <circle cx="20" cy="40" r="15" fill="white" opacity="0.3" />
+  <circle cx="60" cy="100" r="10" fill="white" opacity="0.25" />
+  <circle cx="30" cy="160" r="20" fill="white" opacity="0.35" />
+  <circle cx="50" cy="220" r="12" fill="white" opacity="0.3" />
+  <circle cx="25" cy="270" r="8" fill="white" opacity="0.4" />
+</svg>

--- a/style.css
+++ b/style.css
@@ -51,6 +51,8 @@ h1, h2 {
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  position: relative;
+  overflow: hidden;
 }
 .hero h1,
 .hero p {
@@ -59,6 +61,37 @@ h1, h2 {
   padding: 0.5rem 1rem;
   border-radius: 10px;
   color: white;
+}
+
+/* Ensure hero content appears above decorative elements */
+.hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+/* Bubble decorations on both sides of the hero section */
+.hero::before,
+.hero::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  height: 100%;
+  width: 80px;
+  background-image: url('bubbles.svg');
+  background-repeat: repeat-y;
+  background-size: contain;
+  opacity: 0.5;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.hero::before {
+  left: 0;
+}
+
+.hero::after {
+  right: 0;
+  transform: scaleX(-1);
 }
 .logo {
   max-width: 150px;


### PR DESCRIPTION
## Summary
- add bubble SVG and styles for left/right hero decorations
- ensure hero content layers above bubble elements

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a247879ef08320b784ad01926d5e3e