### PR TITLE
Move hero bubbles outside hero images

### DIFF
--- a/style.css
+++ b/style.css
@@ -10,6 +10,7 @@ body {
   background: var(--main-bg);
   color: var(--text);
   line-height: 1.6;
+  overflow-x: hidden;
 }
 a {
   color: var(--accent);
@@ -52,7 +53,7 @@ h1, h2 {
   justify-content: center;
   align-items: center;
   position: relative;
-  overflow: hidden;
+  overflow: visible;
 }
 .hero h1,
 .hero p {
@@ -69,7 +70,7 @@ h1, h2 {
   z-index: 1;
 }
 
-/* Bubble decorations on both sides of the hero section */
+/* Bubble decorations outside the hero section */
 .hero::before,
 .hero::after {
   content: "";
@@ -86,11 +87,11 @@ h1, h2 {
 }
 
 .hero::before {
-  left: 0;
+  left: -80px;
 }
 
 .hero::after {
-  right: 0;
+  right: -80px;
   transform: scaleX(-1);
 }
 .logo {


### PR DESCRIPTION
## Summary
- Shifted hero bubble pseudo-elements outside the hero images for cleaner presentation
- Allowed hero section to show overflow and hid body x-overflow to keep bubbles from causing scrollbars

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2547a8be48320848a81e4ed69cdd8