### PR TITLE
Add arrow indicator and custom border color to FAQ section

### DIFF
--- a/style.css
+++ b/style.css
@@ -158,12 +158,23 @@ h1, h2 {
   margin-bottom: 2rem;
 }
 .faq-item {
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid #063d49;
   padding: 1rem 0;
   cursor: pointer;
 }
 .faq-question {
   font-weight: bold;
+  position: relative;
+  padding-right: 1.5rem;
+}
+.faq-question::after {
+  content: '\25B6';
+  position: absolute;
+  right: 0;
+  transition: transform 0.3s ease;
+}
+.faq-item.active .faq-question::after {
+  transform: rotate(90deg);
 }
 .faq-answer {
   display: none;


### PR DESCRIPTION
## Summary
- Show right-aligned arrow on FAQ questions that rotates when opened
- Style FAQ separators with brand color #063d49

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2642e1c08832086de20cbc302f83c