### PR TITLE
Fetch Google reviews and enforce API key

### DIFF
--- a/reviews.js
+++ b/reviews.js
@@ -1,1 +1,33 @@
+// Fetch Google reviews and display them on the page
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const ratingEl = document.querySelector('.google-rating');
+  const countEl = document.querySelector('.google-review-count');
+  const reviewsEl = document.querySelector('.google-reviews');
+
+  try {
+    const res = await fetch('/api/reviews');
+    if (!res.ok) throw new Error('Network response was not ok');
+    const { rating, user_ratings_total, reviews } = await res.json();
+
+    if (ratingEl) ratingEl.textContent = `⭐ ${rating.toFixed(1)}`;
+    if (countEl) countEl.textContent = `${user_ratings_total} αξιολογήσεις`;
+
+    if (reviewsEl) {
+      reviewsEl.innerHTML = '';
+      reviews.forEach(r => {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'review';
+        wrapper.innerHTML = `
+          <p><strong>${r.author_name}</strong> - ${r.rating}/5</p>
+          <p>${r.text}</p>
+        `;
+        reviewsEl.appendChild(wrapper);
+      });
+    }
+  } catch (err) {
+    console.error('Error fetching reviews:', err);
+    if (reviewsEl) reviewsEl.textContent = 'Αποτυχία φόρτωσης αξιολογήσεων.';
+  }
+});
 

--- a/server.js
+++ b/server.js
@@ -4,6 +4,11 @@ const path = require('path');
 const url = require('url');
 
 const PLACE_ID = 'ChIJryGcYlWjoRQRimgI2tGaEVc';
+const API_KEY = process.env.GOOGLE_API_KEY;
+if (!API_KEY) {
+  throw new Error('GOOGLE_API_KEY environment variable not set');
+}
+
 
 function serveStaticFile(filePath, res) {
   fs.readFile(filePath, (err, data) => {
@@ -29,13 +34,7 @@ function serveStaticFile(filePath, res) {
 const server = http.createServer(async (req, res) => {
   const parsedUrl = url.parse(req.url, true);
   if (parsedUrl.pathname === '/api/reviews') {
-    const apiKey = process.env.GOOGLE_API_KEY;
-    if (!apiKey) {
-      res.statusCode = 500;
-      res.setHeader('Content-Type', 'application/json');
-      return res.end(JSON.stringify({ error: 'GOOGLE_API_KEY not set' }));
-    }
-    const endpoint = `https://maps.googleapis.com/maps/api/place/details/json?place_id=${PLACE_ID}&fields=rating,user_ratings_total,reviews&key=${apiKey}`;
+    const endpoint = `https://maps.googleapis.com/maps/api/place/details/json?place_id=${PLACE_ID}&fields=rating,user_ratings_total,reviews&key=${API_KEY}`;
     try {
       const response = await fetch(endpoint);
       const data = await response.json();


### PR DESCRIPTION
## Summary
- Load Google reviews on the client with `/api/reviews` fetch and DOM updates
- Add error handling for review fetch failures
- Ensure `GOOGLE_API_KEY` is set before starting the server and reuse it in requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a274a64f508320808c9a4efe55c991