### PR TITLE
Enlarge header logo by 50%

### DIFF
--- a/style.css
+++ b/style.css
@@ -25,8 +25,8 @@ header {
   color: white;
 }
 header img.logo {
-  max-height: 200px;
-  max-width: 200px;
+  max-height: 300px;
+  max-width: 300px;
 }
 section {
   padding: 4rem 1rem;
@@ -281,11 +281,11 @@ footer img.logo {
   }
 }
 
-/* Increase header logo size on desktop screens */
+/* Further increase header logo size on desktop screens */
 @media (min-width: 768px) {
   header img.logo {
-    max-width: 300px;
-    max-height: 300px;
+    max-width: 450px;
+    max-height: 450px;
   }
 }
 #ratings {


### PR DESCRIPTION
## Summary
- enlarge default header logo max dimensions to 300px
- further expand header logo to 450px on desktop screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a39111f9e4832086f5aa80d86a20cf