### PR TITLE
Hide hero decoration on small screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -105,6 +105,13 @@ h1, h2 {
     right: calc(-80px - (50vw - 480px) / 2);
   }
 }
+
+@media (max-width: 600px) {
+  .hero::before,
+  .hero::after {
+    display: none;
+  }
+}
 .logo {
   max-width: 150px;
 }


### PR DESCRIPTION
## Summary
- Hide decorative hero bubbles for viewports ≤600px to avoid mobile overflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a396ef30408320be0e35dd32372673