### PR TITLE
Improve gallery image presentation

### DIFF
--- a/style.css
+++ b/style.css
@@ -133,21 +133,22 @@ h1, h2 {
   border-radius: 5px;
 }
 .gallery-carousel {
-  display: flex;
-  overflow-x: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 1rem;
-  scroll-snap-type: x mandatory;
-  padding-bottom: 1rem;
 }
 .gallery-carousel img {
-  flex: 0 0 auto;
-  scroll-snap-align: center;
-  width: 250px;
-  height: 160px;
+  width: 100%;
+  aspect-ratio: 3 / 2;
   border-radius: 12px;
   box-shadow: 0 2px 10px rgba(0,0,0,0.1);
   object-fit: cover;
-  object-position: center top;
+  object-position: center;
+  transition: transform 0.3s ease;
+}
+
+.gallery-carousel img:hover {
+  transform: scale(1.05);
 }
 .faq {
   max-width: 960px;


### PR DESCRIPTION
## Summary
- Display gallery images in a responsive grid instead of a horizontal scroll
- Center images with a consistent aspect ratio and add a subtle hover scale effect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a397758d98832091cc9bf18a560c10