### PR TITLE
Convert gallery to uniform carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,14 +20,18 @@
   </section>
 
   <section class="gallery-carousel">
-    <img src="dogs/dog1.jpg" alt="Καλλωπισμένος σκύλος 1">
-    <img src="dogs/dog2.jpg" alt="Καλλωπισμένος σκύλος 2">
-    <img src="dogs/dog3.jpg" alt="Καλλωπισμένος σκύλος 3">
-    <img src="dogs/dog4.jpg" alt="Καλλωπισμένος σκύλος 4">
-    <img src="dogs/dog5.jpg" alt="Καλλωπισμένος σκύλος 5">
-    <img src="dogs/dog6.jpg" alt="Καλλωπισμένος σκύλος 6">
-    <img src="dogs/dog7.jpg" alt="Καλλωπισμένος σκύλος 7">
-    <img src="dogs/dog8.jpg" alt="Καλλωπισμένος σκύλος 8">
+    <button class="carousel-btn prev" aria-label="Previous image">&#10094;</button>
+    <div class="carousel-track">
+      <img src="dogs/dog1.jpg" alt="Καλλωπισμένος σκύλος 1">
+      <img src="dogs/dog2.jpg" alt="Καλλωπισμένος σκύλος 2">
+      <img src="dogs/dog3.jpg" alt="Καλλωπισμένος σκύλος 3">
+      <img src="dogs/dog4.jpg" alt="Καλλωπισμένος σκύλος 4">
+      <img src="dogs/dog5.jpg" alt="Καλλωπισμένος σκύλος 5">
+      <img src="dogs/dog6.jpg" alt="Καλλωπισμένος σκύλος 6">
+      <img src="dogs/dog7.jpg" alt="Καλλωπισμένος σκύλος 7">
+      <img src="dogs/dog8.jpg" alt="Καλλωπισμένος σκύλος 8">
+    </div>
+    <button class="carousel-btn next" aria-label="Next image">&#10095;</button>
   </section>
 
   <section class="faq">
@@ -136,6 +140,29 @@
         question.parentElement.classList.toggle('active');
       });
     });
+
+    const track = document.querySelector('.carousel-track');
+    const slides = Array.from(track.children);
+    let currentSlide = 0;
+
+    function showSlide(index) {
+      track.style.transform = `translateX(-${index * 100}%)`;
+    }
+
+    document.querySelector('.carousel-btn.next').addEventListener('click', () => {
+      currentSlide = (currentSlide + 1) % slides.length;
+      showSlide(currentSlide);
+    });
+
+    document.querySelector('.carousel-btn.prev').addEventListener('click', () => {
+      currentSlide = (currentSlide === 0) ? slides.length - 1 : currentSlide - 1;
+      showSlide(currentSlide);
+    });
+
+    setInterval(() => {
+      currentSlide = (currentSlide + 1) % slides.length;
+      showSlide(currentSlide);
+    }, 4000);
   </script>
   <script src="reviews.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -140,22 +140,43 @@ h1, h2 {
   border-radius: 5px;
 }
 .gallery-carousel {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1rem;
+  position: relative;
+  overflow: hidden;
 }
+
+.carousel-track {
+  display: flex;
+  transition: transform 0.5s ease;
+}
+
 .gallery-carousel img {
+  flex: 0 0 100%;
   width: 100%;
   aspect-ratio: 3 / 2;
   border-radius: 12px;
   box-shadow: 0 2px 10px rgba(0,0,0,0.1);
   object-fit: cover;
   object-position: center;
-  transition: transform 0.3s ease;
 }
 
-.gallery-carousel img:hover {
-  transform: scale(1.05);
+.carousel-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(0, 0, 0, 0.5);
+  border: none;
+  color: white;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  border-radius: 50%;
+}
+
+.carousel-btn.prev {
+  left: 0.5rem;
+}
+
+.carousel-btn.next {
+  right: 0.5rem;
 }
 .faq {
   max-width: 960px;


### PR DESCRIPTION
## Summary
- Replace static gallery grid with carousel structure and controls
- Add JavaScript logic to cycle through images and auto-advance
- Style carousel for uniform image sizing and navigation buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a39aae50348320a4874a32b1203fbf