### PR TITLE
Shrink gallery carousel and add hover hint

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
       <img src="dogs/dog7.jpg" alt="Καλλωπισμένος σκύλος 7">
       <img src="dogs/dog8.jpg" alt="Καλλωπισμένος σκύλος 8">
     </div>
+    <div class="hover-bar"></div>
     <button class="carousel-btn next" aria-label="Next image">&#10095;</button>
   </section>
 
@@ -157,26 +158,46 @@
 
     const track = document.querySelector('.carousel-track');
     const slides = Array.from(track.children);
-    let currentSlide = 0;
+    const firstClone = slides[0].cloneNode(true);
+    const lastClone = slides[slides.length - 1].cloneNode(true);
+    firstClone.id = 'first-clone';
+    lastClone.id = 'last-clone';
+    track.appendChild(firstClone);
+    track.insertBefore(lastClone, slides[0]);
 
-    function showSlide(index) {
-      track.style.transform = `translateX(-${index * 100}%)`;
+    const allSlides = Array.from(track.children);
+    let currentSlide = 1;
+    const gap = parseInt(getComputedStyle(track).gap) || 0;
+    const slideWidth = allSlides[currentSlide].getBoundingClientRect().width + gap;
+    track.style.transform = `translateX(-${slideWidth * currentSlide}px)`;
+
+    function showSlide() {
+      track.style.transition = 'transform 0.5s ease';
+      track.style.transform = `translateX(-${slideWidth * currentSlide}px)`;
     }
 
     document.querySelector('.carousel-btn.next').addEventListener('click', () => {
-      currentSlide = (currentSlide + 1) % slides.length;
-      showSlide(currentSlide);
+      currentSlide++;
+      showSlide();
     });
 
     document.querySelector('.carousel-btn.prev').addEventListener('click', () => {
-      currentSlide = (currentSlide === 0) ? slides.length - 1 : currentSlide - 1;
-      showSlide(currentSlide);
+      currentSlide--;
+      showSlide();
     });
 
-    setInterval(() => {
-      currentSlide = (currentSlide + 1) % slides.length;
-      showSlide(currentSlide);
-    }, 4000);
+    track.addEventListener('transitionend', () => {
+      if (allSlides[currentSlide].id === 'first-clone') {
+        track.style.transition = 'none';
+        currentSlide = 1;
+        track.style.transform = `translateX(-${slideWidth * currentSlide}px)`;
+      }
+      if (allSlides[currentSlide].id === 'last-clone') {
+        track.style.transition = 'none';
+        currentSlide = allSlides.length - 2;
+        track.style.transform = `translateX(-${slideWidth * currentSlide}px)`;
+      }
+    });
   </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -142,21 +142,39 @@ h1, h2 {
 .gallery-carousel {
   position: relative;
   overflow: hidden;
+  width: 25%;
+  margin: 0 auto;
 }
 
 .carousel-track {
   display: flex;
   transition: transform 0.5s ease;
+  gap: 0.5rem;
 }
 
 .gallery-carousel img {
-  flex: 0 0 100%;
+  flex: 0 0 calc(100% - 0.5rem);
   width: 100%;
   aspect-ratio: 3 / 2;
   border-radius: 12px;
   box-shadow: 0 2px 10px rgba(0,0,0,0.1);
   object-fit: cover;
   object-position: center;
+}
+
+.hover-bar {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 10px;
+  background: var(--accent);
+  transform: translateY(100%);
+  transition: transform 0.3s ease;
+}
+
+.gallery-carousel:hover .hover-bar {
+  transform: translateY(0);
 }
 
 .carousel-btn {
@@ -169,6 +187,7 @@ h1, h2 {
   padding: 0.5rem 0.75rem;
   cursor: pointer;
   border-radius: 50%;
+  z-index: 2;
 }
 
 .carousel-btn.prev {


### PR DESCRIPTION
## Summary
- Shrink gallery carousel to 25% width so images appear smaller yet centered
- Add hover bar beneath gallery to signal manual carousel control
- Keep carousel navigation manual via button clicks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3afe07e9c8320b4a159c38117fd03