### PR TITLE
Add social icons to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,14 @@
 
   <header>
     <img src="logo/logo.png" alt="Pawsh logo" class="logo">
+    <div class="header-socials">
+      <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank" rel="noopener">
+        <img src="logo/facebooklogo.svg" alt="Facebook">
+      </a>
+      <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank" rel="noopener">
+        <img src="logo/Instagramlogo.svg" alt="Instagram">
+      </a>
+    </div>
   </header>
 
   <section class="hero">

--- a/style.css
+++ b/style.css
@@ -23,10 +23,22 @@ header {
   justify-content: center;
   align-items: center;
   color: white;
+  position: relative;
 }
 header img.logo {
   max-height: 300px;
   max-width: 300px;
+}
+.header-socials {
+  position: absolute;
+  right: 1rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.header-socials img {
+  width: 16px;
+  height: 16px;
 }
 section {
   padding: 4rem 1rem;


### PR DESCRIPTION
## Summary
- Add Facebook and Instagram icons to site header with outbound links
- Style header social icons at 16px and position them in top-right

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3be9f806c8320bd650b5770c34fbc