### PR TITLE
Enable scrollable looping gallery carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,6 @@
   </section>
 
   <section class="gallery-carousel">
-    <button class="carousel-btn prev" aria-label="Previous image">&#10094;</button>
     <div class="carousel-track">
       <img src="dogs/dog1.jpg" alt="Καλλωπισμένος σκύλος 1">
       <img src="dogs/dog2.jpg" alt="Καλλωπισμένος σκύλος 2">
@@ -35,9 +34,6 @@
       <img src="dogs/dog7.jpg" alt="Καλλωπισμένος σκύλος 7">
       <img src="dogs/dog8.jpg" alt="Καλλωπισμένος σκύλος 8">
     </div>
-    <div class="hover-bar"></div>
-    <button class="carousel-btn next" aria-label="Next image">&#10095;</button>
-    <div class="carousel-hover-bar"></div>
   </section>
 
   <section class="faq">
@@ -165,30 +161,28 @@
     const slides = Array.from(track.children);
     const firstClone = slides[0].cloneNode(true);
     const lastClone = slides[slides.length - 1].cloneNode(true);
-    firstClone.id = 'first-clone';
-    lastClone.id = 'last-clone';
     track.appendChild(firstClone);
     track.insertBefore(lastClone, slides[0]);
 
-    const allSlides = Array.from(track.children);
-    let currentSlide = 1;
     const gap = parseInt(getComputedStyle(track).gap) || 0;
-    const slideWidth = allSlides[currentSlide].getBoundingClientRect().width + gap;
-    track.style.transform = `translateX(-${slideWidth * currentSlide}px)`;
+    const slideWidth = slides[0].getBoundingClientRect().width + gap;
+    track.scrollLeft = slideWidth;
 
-    function showSlide() {
-      track.style.transition = 'transform 0.5s ease';
-      track.style.transform = `translateX(-${slideWidth * currentSlide}px)`;
-    }
+    track.addEventListener('wheel', (e) => {
+      e.preventDefault();
+      track.scrollLeft += e.deltaY;
+    }, { passive: false });
 
-    document.querySelector('.carousel-btn.next').addEventListener('click', () => {
-      currentSlide++;
-      showSlide();
-    });
-
-    document.querySelector('.carousel-btn.prev').addEventListener('click', () => {
-      currentSlide--;
-      showSlide();
+    track.addEventListener('scroll', () => {
+      if (track.scrollLeft <= 0) {
+        track.style.scrollBehavior = 'auto';
+        track.scrollLeft = slideWidth * slides.length;
+        track.style.scrollBehavior = 'smooth';
+      } else if (track.scrollLeft >= slideWidth * (slides.length + 1)) {
+        track.style.scrollBehavior = 'auto';
+        track.scrollLeft = slideWidth;
+        track.style.scrollBehavior = 'smooth';
+      }
     });
   </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -145,15 +145,21 @@ h1, h2 {
   border-radius: 5px;
 }
 .gallery-carousel {
-  position: relative;
   overflow: hidden;
   margin: 0 auto;
 }
 
 .carousel-track {
   display: flex;
-  transition: transform 0.5s ease;
   gap: 0.5rem;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  scroll-behavior: smooth;
+}
+
+.carousel-track::-webkit-scrollbar {
+  display: none;
 }
 
 .gallery-carousel img {
@@ -164,33 +170,7 @@ h1, h2 {
   box-shadow: 0 2px 10px rgba(0,0,0,0.1);
   object-fit: cover;
   object-position: center;
-}
-
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-}
-
-.carousel-btn {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  background: rgba(0, 0, 0, 0.5);
-  border: none;
-  color: white;
-  padding: 0.5rem 0.75rem;
-  cursor: pointer;
-  border-radius: 50%;
-  z-index: 2;
-}
-
-.carousel-btn.prev {
-  left: 0.5rem;
-}
-
-.carousel-btn.next {
-  right: 0.5rem;
+  scroll-snap-align: center;
 }
 .faq {
   max-width: 960px;


### PR DESCRIPTION
## Summary
- Convert gallery into a scrollable carousel usable with mouse wheel or touch gestures
- Loop from last to first image seamlessly by cloning slides and resetting scroll position
- Simplify carousel styling with scroll snapping and hidden scrollbars

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d3baa4a08320bf1df876e472f5d0