### PR TITLE
style: enhance FAQ item layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -135,31 +135,36 @@ h1, h2 {
   margin-bottom: 2rem;
 }
 .faq-item {
-  border-bottom: 1px solid #063d49;
-  padding: 1rem 0;
-  cursor: pointer;
+  background: #fff;
+  border: 1px solid rgba(6, 61, 73, 0.3);
+  border-radius: 8px;
+  padding: 1rem 1.5rem;
+  margin-bottom: 1rem;
 }
 .faq-question {
   font-weight: bold;
   position: relative;
   padding-right: 1.5rem;
+  cursor: pointer;
 }
 .faq-question::after {
   content: '\25B6';
   position: absolute;
   right: 0;
+  top: 50%;
+  transform: translateY(-50%);
   transition: transform 0.3s ease;
 }
 .faq-item.active .faq-question::after {
-  transform: rotate(90deg);
+  transform: translateY(-50%) rotate(90deg);
 }
 .faq-answer {
   display: none;
   margin-top: 0.5rem;
 }
-  .faq-item.active .faq-answer {
-    display: block;
-  }
+.faq-item.active .faq-answer {
+  display: block;
+}
 
   .reviews {
     text-align: center;


### PR DESCRIPTION
## Summary
- style FAQ items as distinct cards with white background, subtle border, rounded corners, and margin spacing
- center FAQ arrow indicator and preserve expand/collapse behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab3ac36c748320ad174c4dbf7ce997