### PR TITLE
Add About Us page with owner profile and routing

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,1 +1,67 @@
+<!DOCTYPE html>
+<html lang="el">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Μάθετε περισσότερα για την ομάδα του Pawsh Pet Salon">
+  <title>Σχετικά με εμάς - Pawsh Pet Salon</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <img src="logo/logo.png" alt="Pawsh logo" class="logo">
+    <div class="header-socials">
+      <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank" rel="noopener">
+        <img src="logo/facebook icon.png" alt="Facebook">
+      </a>
+      <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank" rel="noopener">
+        <img src="logo/instagram icon.png" alt="Instagram">
+      </a>
+    </div>
+  </header>
 
+  <section class="about-section">
+    <div class="about-text">
+      <h1>Γνωρίστε την Αλεξάνδρα</h1>
+      <p>Η Αλεξάνδρα είναι η ιδιοκτήτρια και η καρδιά του Pawsh Pet Salon. Με πολυετή εμπειρία στο grooming και απεριόριστη αγάπη για τα ζώα, φροντίζει κάθε επισκέπτη σαν να είναι το δικό της κατοικίδιο.</p>
+      <a href="https://pawshpetbeautysalon.setmore.com" class="btn" target="_blank" rel="noopener">Κλείσε Ραντεβού</a>
+    </div>
+    <div class="about-image">
+      <div class="photo-placeholder" aria-label="Φωτογραφία της Αλεξάνδρας"></div>
+    </div>
+  </section>
+
+  <footer>
+    <div class="footer-column">
+      <h4>Στοιχεία Επικοινωνίας</h4>
+      <p>Διεύθυνση: Αγίας Γλυκερίας 62, Γαλάτσι 111 47</p>
+      <p>Τηλέφωνο: 21 0440 4084</p>
+      <p>Email: pawsh.petgroomingsalon@gmail.com</p>
+    </div>
+    <div class="footer-column">
+      <img src="logo/logo2.png" alt="Pawsh logo" class="logo">
+      <div class="footer-socials">
+        <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
+          <img src="logo/facebook icon.png" alt="Facebook">
+        </a>
+        <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
+          <img src="logo/instagram icon.png" alt="Instagram">
+        </a>
+      </div>
+      <div class="footer-links">
+        <a href="about.html">Σχετικά με εμάς</a>
+        <a href="terms.html" target="_blank" rel="noopener">Όροι και Προϋποθέσεις</a>
+        <a href="privacy.html" target="_blank" rel="noopener">Πολιτική Απορρήτου</a>
+      </div>
+      <p style="margin-top: 1rem;">&copy; 2025 Pawsh Pet Salon. All rights reserved.</p>
+    </div>
+    <div class="footer-column">
+      <h4>Ωράριο Καταστήματος</h4>
+      <p>Δευτέρα: Κλειστά</p>
+      <p>Τρίτη - Παρασκευή: 10:00 π.μ.–6:00 μ.μ.</p>
+      <p>Σάββατο: 10:00 π.μ.–3:00 μ.μ.</p>
+      <p>Κυριακή: Κλειστά</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -173,6 +173,7 @@
         </a>
       </div>
       <div class="footer-links">
+        <a href="about.html">Σχετικά με εμάς</a>
         <a href="terms.html" target="_blank" rel="noopener">Όροι και Προϋποθέσεις</a>
         <a href="privacy.html" target="_blank" rel="noopener">Πολιτική Απορρήτου</a>
       </div>

--- a/server.js
+++ b/server.js
@@ -28,6 +28,7 @@ const server = http.createServer((req, res) => {
   const parsedUrl = url.parse(req.url, true);
   let pathname = parsedUrl.pathname;
   if (pathname === '/') pathname = '/index.html';
+  if (pathname === '/about') pathname = '/about.html';
   const filePath = path.join(__dirname, pathname);
   serveStaticFile(filePath, res);
 });

--- a/style.css
+++ b/style.css
@@ -332,3 +332,46 @@ footer img.logo {
     max-height: 450px;
   }
 }
+.about-section {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+  gap: 2rem;
+}
+.about-text {
+  flex: 1 1 300px;
+}
+.about-image {
+  flex: 1 1 250px;
+  text-align: right;
+}
+.about-image img {
+  max-width: 100%;
+  border-radius: 8px;
+}
+.photo-placeholder {
+  width: 250px;
+  height: 250px;
+  background: #eee;
+  border-radius: 8px;
+  margin-left: auto;
+}
+.team-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+.team-member img {
+  width: 100%;
+  height: auto;
+  border-radius: 8px;
+}
+.team-member h3 {
+  margin-top: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- Create `about.html` with Alexandra owner profile, placeholder area, and booking CTA
- Link About page in footer navigation and add styling for about layout and team grid
- Route `/about` to `about.html` in the server
- Replace binary owner image with CSS-based placeholder to avoid unsupported binary assets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab41ba85bc832080249032f6273257