### PR TITLE
Use mobile-specific logo

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,7 +9,10 @@
 </head>
 <body>
   <header>
-    <img src="logo/logo.png" alt="Pawsh logo" class="logo">
+    <picture>
+      <source srcset="logo/logo1.png" media="(max-width: 600px)">
+      <img src="logo/logo.png" alt="Pawsh logo" class="logo">
+    </picture>
     <div class="header-socials">
       <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank" rel="noopener">
         <img src="logo/facebook icon.png" alt="Facebook">

--- a/index.html
+++ b/index.html
@@ -10,7 +10,10 @@
 <body>
 
   <header>
-    <img src="logo/logo.png" alt="Pawsh logo" class="logo">
+    <picture>
+      <source srcset="logo/logo1.png" media="(max-width: 600px)">
+      <img src="logo/logo.png" alt="Pawsh logo" class="logo">
+    </picture>
     <div class="header-socials">
       <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank" rel="noopener">
         <img src="logo/facebook icon.png" alt="Facebook">

--- a/style.css
+++ b/style.css
@@ -33,6 +33,8 @@ header img.logo {
 .header-socials {
   position: absolute;
   right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
   display: flex;
   gap: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- Serve alternate logo image on small screens using a `<picture>` element.
- Vertically center header social links to prevent overlap with the logo.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab499c32908320b7a2015b34c7df85