### PR TITLE
Align header logo left on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -30,6 +30,12 @@ header img.logo {
   max-width: 300px;
 }
 
+@media (max-width: 600px) {
+  header {
+    justify-content: flex-start;
+  }
+}
+
 .header-socials {
   position: absolute;
   right: 1rem;


### PR DESCRIPTION
## Summary
- Align logo to the left in the header on mobile devices for improved layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab4ea08ab883208cc6961e736e59b3