### PR TITLE
Implement responsive Tailwind navigation and clean up footer links

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,22 +5,37 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Μάθετε περισσότερα για την ομάδα του Pawsh Pet Salon">
   <title>Σχετικά με εμάς - Pawsh Pet Salon</title>
+  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <header>
-    <picture>
-      <source srcset="logo/logo1.png" media="(max-width: 600px)">
-      <img src="logo/logo.png" alt="Pawsh logo" class="logo">
-    </picture>
-    <div class="header-socials">
-      <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank" rel="noopener">
-        <img src="logo/facebook icon.png" alt="Facebook">
-      </a>
-      <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank" rel="noopener">
-        <img src="logo/instagram icon.png" alt="Instagram">
-      </a>
+  <header class="bg-[#063d49] text-white">
+    <div class="flex items-center justify-between p-4">
+      <button id="menu-button" class="sm:hidden" aria-label="Toggle menu">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
+      <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
+      <div class="w-8"></div>
     </div>
+    <div class="border-b-2 border-[#d7c9a9]"></div>
+    <nav class="hidden sm:flex justify-center space-x-8 py-4">
+      <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Home</a>
+      <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">About Us</a>
+      <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Gallery</a>
+      <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Services</a>
+      <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Contact</a>
+    </nav>
+    <nav id="mobile-menu" class="sm:hidden max-h-0 overflow-hidden transition-all duration-300">
+      <div class="flex flex-col items-center py-2 space-y-2">
+        <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Home</a>
+        <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">About Us</a>
+        <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Gallery</a>
+        <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Services</a>
+        <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Contact</a>
+      </div>
+    </nav>
   </header>
 
   <section class="about-section">
@@ -34,7 +49,7 @@
     </div>
   </section>
 
-  <footer>
+  <footer id="contact">
     <div class="footer-column">
       <h4>Στοιχεία Επικοινωνίας</h4>
       <p>Διεύθυνση: Αγίας Γλυκερίας 62, Γαλάτσι 111 47</p>
@@ -52,7 +67,6 @@
         </a>
       </div>
       <div class="footer-links">
-        <a href="about.html">Σχετικά με εμάς</a>
         <a href="terms.html" target="_blank" rel="noopener">Όροι και Προϋποθέσεις</a>
         <a href="privacy.html" target="_blank" rel="noopener">Πολιτική Απορρήτου</a>
       </div>
@@ -66,5 +80,15 @@
       <p>Κυριακή: Κλειστά</p>
     </div>
   </footer>
+  <script>
+    const menuButton = document.getElementById('menu-button');
+    const mobileMenu = document.getElementById('mobile-menu');
+    if (menuButton && mobileMenu) {
+      menuButton.addEventListener('click', () => {
+        mobileMenu.classList.toggle('max-h-0');
+        mobileMenu.classList.toggle('max-h-96');
+      });
+    }
+  </script>
 </body>
 </html>

--- a/gallery.html
+++ b/gallery.html
@@ -1,1 +1,85 @@
-
+<!DOCTYPE html>
+<html lang="el">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gallery - Pawsh Pet Salon</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="bg-[#063d49] text-white">
+    <div class="flex items-center justify-between p-4">
+      <button id="menu-button" class="sm:hidden" aria-label="Toggle menu">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
+      <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
+      <div class="w-8"></div>
+    </div>
+    <div class="border-b-2 border-[#d7c9a9]"></div>
+    <nav class="hidden sm:flex justify-center space-x-8 py-4">
+      <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Home</a>
+      <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">About Us</a>
+      <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Gallery</a>
+      <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Services</a>
+      <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Contact</a>
+    </nav>
+    <nav id="mobile-menu" class="sm:hidden max-h-0 overflow-hidden transition-all duration-300">
+      <div class="flex flex-col items-center py-2 space-y-2">
+        <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Home</a>
+        <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">About Us</a>
+        <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Gallery</a>
+        <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Services</a>
+        <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Contact</a>
+      </div>
+    </nav>
+  </header>
+  <main class="py-8">
+    <h1 class="text-center text-2xl font-bold">Gallery</h1>
+    <p class="text-center mt-4">Coming soon...</p>
+  </main>
+  <footer id="contact">
+    <div class="footer-column">
+      <h4>Στοιχεία Επικοινωνίας</h4>
+      <p>Διεύθυνση: Αγίας Γλυκερίας 62, Γαλάτσι 111 47</p>
+      <p>Τηλέφωνο: 21 0440 4084</p>
+      <p>Email: pawsh.petgroomingsalon@gmail.com</p>
+    </div>
+    <div class="footer-column">
+      <img src="logo/logo2.png" alt="Pawsh logo" class="logo">
+      <div class="footer-socials">
+        <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
+          <img src="logo/facebook icon.png" alt="Facebook">
+        </a>
+        <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
+          <img src="logo/instagram icon.png" alt="Instagram">
+        </a>
+      </div>
+      <div class="footer-links">
+        <a href="terms.html" target="_blank" rel="noopener">Όροι και Προϋποθέσεις</a>
+        <a href="privacy.html" target="_blank" rel="noopener">Πολιτική Απορρήτου</a>
+      </div>
+      <p style="margin-top: 1rem;">&copy; 2025 Pawsh Pet Salon. All rights reserved.</p>
+    </div>
+    <div class="footer-column">
+      <h4>Ωράριο Καταστήματος</h4>
+      <p>Δευτέρα: Κλειστά</p>
+      <p>Τρίτη - Παρασκευή: 10:00 π.μ.–6:00 μ.μ.</p>
+      <p>Σάββατο: 10:00 π.μ.–3:00 μ.μ.</p>
+      <p>Κυριακή: Κλειστά</p>
+    </div>
+  </footer>
+  <script>
+    const menuButton = document.getElementById('menu-button');
+    const mobileMenu = document.getElementById('mobile-menu');
+    if (menuButton && mobileMenu) {
+      menuButton.addEventListener('click', () => {
+        mobileMenu.classList.toggle('max-h-0');
+        mobileMenu.classList.toggle('max-h-96');
+      });
+    }
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -5,23 +5,38 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Pet grooming salon in Galatsi offering professional services">
   <title>Pawsh - Pet Beauty Salon</title>
+  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
 
-  <header>
-    <picture>
-      <source srcset="logo/logo1.png" media="(max-width: 600px)">
-      <img src="logo/logo.png" alt="Pawsh logo" class="logo">
-    </picture>
-    <div class="header-socials">
-      <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank" rel="noopener">
-        <img src="logo/facebook icon.png" alt="Facebook">
-      </a>
-      <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank" rel="noopener">
-        <img src="logo/instagram icon.png" alt="Instagram">
-      </a>
+  <header class="bg-[#063d49] text-white">
+    <div class="flex items-center justify-between p-4">
+      <button id="menu-button" class="sm:hidden" aria-label="Toggle menu">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
+      <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
+      <div class="w-8"></div>
     </div>
+    <div class="border-b-2 border-[#d7c9a9]"></div>
+    <nav class="hidden sm:flex justify-center space-x-8 py-4">
+      <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Home</a>
+      <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">About Us</a>
+      <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Gallery</a>
+      <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Services</a>
+      <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Contact</a>
+    </nav>
+    <nav id="mobile-menu" class="sm:hidden max-h-0 overflow-hidden transition-all duration-300">
+      <div class="flex flex-col items-center py-2 space-y-2">
+        <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Home</a>
+        <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">About Us</a>
+        <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Gallery</a>
+        <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Services</a>
+        <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Contact</a>
+      </div>
+    </nav>
   </header>
 
   <section class="hero">
@@ -158,7 +173,7 @@
       <iframe src="https://www.google.com/maps?q=Αγίας+Γλυκερίας+62,+Γαλάτσι,+111+47&output=embed"></iframe>
     </section>
 
-  <footer>
+  <footer id="contact">
     <div class="footer-column">
       <h4>Στοιχεία Επικοινωνίας</h4>
       <p>Διεύθυνση: Αγίας Γλυκερίας 62, Γαλάτσι 111 47</p>
@@ -176,7 +191,6 @@
         </a>
       </div>
       <div class="footer-links">
-        <a href="about.html">Σχετικά με εμάς</a>
         <a href="terms.html" target="_blank" rel="noopener">Όροι και Προϋποθέσεις</a>
         <a href="privacy.html" target="_blank" rel="noopener">Πολιτική Απορρήτου</a>
       </div>
@@ -191,6 +205,14 @@
     </div>
   </footer>
   <script>
+    const menuButton = document.getElementById('menu-button');
+    const mobileMenu = document.getElementById('mobile-menu');
+    if (menuButton && mobileMenu) {
+      menuButton.addEventListener('click', () => {
+        mobileMenu.classList.toggle('max-h-0');
+        mobileMenu.classList.toggle('max-h-96');
+      });
+    }
     const heroImages = [
       'Pawsh pet salon/Pawsh pet salon 1.jpg',
       'Pawsh pet salon/Pawsh pet salon 10.jpg',


### PR DESCRIPTION
## Summary
- add Tailwind-powered responsive navigation bar with centered logo and dropdown menu
- remove "About Us" link from footers and mark contact section for navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab62b663148320899ff9362554a3d4