### PR TITLE
Use alternate logo on mobile

### DIFF
--- a/about.html
+++ b/about.html
@@ -16,7 +16,10 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
         </svg>
       </button>
-      <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
+      <picture>
+        <source media="(max-width: 600px)" srcset="logo/logo2.png">
+        <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
+      </picture>
       <div class="w-8"></div>
     </div>
     <div class="border-b-2 border-[#d7c9a9]"></div>

--- a/gallery.html
+++ b/gallery.html
@@ -15,7 +15,10 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
         </svg>
       </button>
-      <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
+      <picture>
+        <source media="(max-width: 600px)" srcset="logo/logo2.png">
+        <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
+      </picture>
       <div class="w-8"></div>
     </div>
     <div class="border-b-2 border-[#d7c9a9]"></div>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,10 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
         </svg>
       </button>
-      <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
+      <picture>
+        <source media="(max-width: 600px)" srcset="logo/logo2.png">
+        <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
+      </picture>
       <div class="w-8"></div>
     </div>
     <div class="border-b-2 border-[#d7c9a9]"></div>


### PR DESCRIPTION
## Summary
- Display `logo2.png` on small screens using responsive picture elements

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab65ee23f48320bfb941b1dca095d3