### PR TITLE
Add right-side mobile navigation menu

### DIFF
--- a/about.html
+++ b/about.html
@@ -24,7 +24,19 @@
     </div>
     <div class="border-b-2 border-[#d7c9a9]"></div>
     <nav class="hidden sm:flex justify-center space-x-8 py-4">
-
+      <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Αρχική</a>
+      <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Σχετικά με εμάς</a>
+      <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Συλλογή</a>
+      <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Υπηρεσίες</a>
+      <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Επικοινωνία</a>
+    </nav>
+    <nav id="mobile-menu" class="sm:hidden fixed top-0 right-0 h-full w-2/3 bg-[#063d49] text-white transform translate-x-full transition-transform duration-300 z-40">
+      <div class="flex flex-col items-center mt-20 space-y-4">
+        <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Αρχική</a>
+        <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Σχετικά με εμάς</a>
+        <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Συλλογή</a>
+        <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Υπηρεσίες</a>
+        <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Επικοινωνία</a>
       </div>
     </nav>
   </header>
@@ -76,6 +88,8 @@
     const mobileMenu = document.getElementById('mobile-menu');
     if (menuButton && mobileMenu) {
       menuButton.addEventListener('click', () => {
+        mobileMenu.classList.toggle('translate-x-full');
+        mobileMenu.classList.toggle('translate-x-0');
       });
     }
   </script>

--- a/gallery.html
+++ b/gallery.html
@@ -22,6 +22,19 @@
     </div>
     <div class="border-b-2 border-[#d7c9a9]"></div>
     <nav class="hidden sm:flex justify-center space-x-8 py-4">
+      <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Αρχική</a>
+      <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Σχετικά με εμάς</a>
+      <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Συλλογή</a>
+      <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Υπηρεσίες</a>
+      <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Επικοινωνία</a>
+    </nav>
+    <nav id="mobile-menu" class="sm:hidden fixed top-0 right-0 h-full w-2/3 bg-[#063d49] text-white transform translate-x-full transition-transform duration-300 z-40">
+      <div class="flex flex-col items-center mt-20 space-y-4">
+        <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Αρχική</a>
+        <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Σχετικά με εμάς</a>
+        <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Συλλογή</a>
+        <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Υπηρεσίες</a>
+        <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Επικοινωνία</a>
       </div>
     </nav>
   </header>
@@ -63,6 +76,8 @@
     const mobileMenu = document.getElementById('mobile-menu');
     if (menuButton && mobileMenu) {
       menuButton.addEventListener('click', () => {
+        mobileMenu.classList.toggle('translate-x-full');
+        mobileMenu.classList.toggle('translate-x-0');
       });
     }
   </script>

--- a/index.html
+++ b/index.html
@@ -25,6 +25,19 @@
     </div>
     <div class="border-b-2 border-[#d7c9a9]"></div>
     <nav class="hidden sm:flex justify-center space-x-8 py-4">
+      <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Αρχική</a>
+      <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Σχετικά με εμάς</a>
+      <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Συλλογή</a>
+      <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Υπηρεσίες</a>
+      <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Επικοινωνία</a>
+    </nav>
+    <nav id="mobile-menu" class="sm:hidden fixed top-0 right-0 h-full w-2/3 bg-[#063d49] text-white transform translate-x-full transition-transform duration-300 z-40">
+      <div class="flex flex-col items-center mt-20 space-y-4">
+        <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Αρχική</a>
+        <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Σχετικά με εμάς</a>
+        <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Συλλογή</a>
+        <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Υπηρεσίες</a>
+        <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Επικοινωνία</a>
       </div>
     </nav>
   </header>
@@ -199,6 +212,8 @@
     const mobileMenu = document.getElementById('mobile-menu');
     if (menuButton && mobileMenu) {
       menuButton.addEventListener('click', () => {
+        mobileMenu.classList.toggle('translate-x-full');
+        mobileMenu.classList.toggle('translate-x-0');
       });
     }
     const heroImages = [


### PR DESCRIPTION
## Summary
- Add desktop and mobile navigation links to index, about, and gallery pages.
- Implement right-side slide-in mobile menu and toggle script.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab68f6a80c83208f35ad126f61667e