### PR TITLE
Add right-side mobile navigation menu

### DIFF
--- a/about.html
+++ b/about.html
@@ -11,20 +11,32 @@
 <body>
   <header class="bg-[#063d49] text-white">
     <div class="flex items-center justify-between p-4">
+      <div class="w-8"></div>
+      <picture>
+        <source media="(max-width: 600px)" srcset="logo/logo2.png">
+        <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
+      </picture>
       <button id="menu-button" class="sm:hidden" aria-label="Toggle menu">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
         </svg>
       </button>
-      <picture>
-        <source media="(max-width: 600px)" srcset="logo/logo2.png">
-        <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
-      </picture>
-      <div class="w-8"></div>
     </div>
     <div class="border-b-2 border-[#d7c9a9]"></div>
     <nav class="hidden sm:flex justify-center space-x-8 py-4">
-
+      <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Αρχική</a>
+      <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Σχετικά με εμάς</a>
+      <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Συλλογή</a>
+      <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Υπηρεσίες</a>
+      <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Επικοινωνία</a>
+    </nav>
+    <nav id="mobile-menu" class="sm:hidden fixed top-0 right-0 h-full w-2/3 bg-[#063d49] text-white transform translate-x-full transition-transform duration-300 z-40">
+      <div class="flex flex-col items-center mt-20 space-y-4">
+        <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Αρχική</a>
+        <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Σχετικά με εμάς</a>
+        <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Συλλογή</a>
+        <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Υπηρεσίες</a>
+        <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Επικοινωνία</a>
       </div>
     </nav>
   </header>
@@ -76,6 +88,8 @@
     const mobileMenu = document.getElementById('mobile-menu');
     if (menuButton && mobileMenu) {
       menuButton.addEventListener('click', () => {
+        mobileMenu.classList.toggle('translate-x-full');
+        mobileMenu.classList.toggle('translate-x-0');
       });
     }
   </script>

--- a/gallery.html
+++ b/gallery.html
@@ -9,19 +9,32 @@
 <body>
   <header class="bg-[#063d49] text-white">
     <div class="flex items-center justify-between p-4">
+      <div class="w-8"></div>
+      <picture>
+        <source media="(max-width: 600px)" srcset="logo/logo2.png">
+        <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
+      </picture>
       <button id="menu-button" class="sm:hidden" aria-label="Toggle menu">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
         </svg>
       </button>
-      <picture>
-        <source media="(max-width: 600px)" srcset="logo/logo2.png">
-        <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
-      </picture>
-      <div class="w-8"></div>
     </div>
     <div class="border-b-2 border-[#d7c9a9]"></div>
     <nav class="hidden sm:flex justify-center space-x-8 py-4">
+      <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Αρχική</a>
+      <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Σχετικά με εμάς</a>
+      <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Συλλογή</a>
+      <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Υπηρεσίες</a>
+      <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Επικοινωνία</a>
+    </nav>
+    <nav id="mobile-menu" class="sm:hidden fixed top-0 right-0 h-full w-2/3 bg-[#063d49] text-white transform translate-x-full transition-transform duration-300 z-40">
+      <div class="flex flex-col items-center mt-20 space-y-4">
+        <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Αρχική</a>
+        <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Σχετικά με εμάς</a>
+        <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Συλλογή</a>
+        <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Υπηρεσίες</a>
+        <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Επικοινωνία</a>
       </div>
     </nav>
   </header>
@@ -63,6 +76,8 @@
     const mobileMenu = document.getElementById('mobile-menu');
     if (menuButton && mobileMenu) {
       menuButton.addEventListener('click', () => {
+        mobileMenu.classList.toggle('translate-x-full');
+        mobileMenu.classList.toggle('translate-x-0');
       });
     }
   </script>

--- a/index.html
+++ b/index.html
@@ -12,19 +12,32 @@
 
   <header class="bg-[#063d49] text-white">
     <div class="flex items-center justify-between p-4">
+      <div class="w-8"></div>
+      <picture>
+        <source media="(max-width: 600px)" srcset="logo/logo2.png">
+        <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
+      </picture>
       <button id="menu-button" class="sm:hidden" aria-label="Toggle menu">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
         </svg>
       </button>
-      <picture>
-        <source media="(max-width: 600px)" srcset="logo/logo2.png">
-        <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
-      </picture>
-      <div class="w-8"></div>
     </div>
     <div class="border-b-2 border-[#d7c9a9]"></div>
     <nav class="hidden sm:flex justify-center space-x-8 py-4">
+      <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Αρχική</a>
+      <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Σχετικά με εμάς</a>
+      <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Συλλογή</a>
+      <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Υπηρεσίες</a>
+      <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Επικοινωνία</a>
+    </nav>
+    <nav id="mobile-menu" class="sm:hidden fixed top-0 right-0 h-full w-2/3 bg-[#063d49] text-white transform translate-x-full transition-transform duration-300 z-40">
+      <div class="flex flex-col items-center mt-20 space-y-4">
+        <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Αρχική</a>
+        <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Σχετικά με εμάς</a>
+        <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Συλλογή</a>
+        <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Υπηρεσίες</a>
+        <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Επικοινωνία</a>
       </div>
     </nav>
   </header>
@@ -199,6 +212,8 @@
     const mobileMenu = document.getElementById('mobile-menu');
     if (menuButton && mobileMenu) {
       menuButton.addEventListener('click', () => {
+        mobileMenu.classList.toggle('translate-x-full');
+        mobileMenu.classList.toggle('translate-x-0');
       });
     }
     const heroImages = [


### PR DESCRIPTION
## Summary
- Add desktop and mobile navigation links to index, about, and gallery pages.
- Implement right-side slide-in mobile menu and toggle script.
- Place the hamburger menu button on the right so it matches the menu location.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab68f6a80c83208f35ad126f61667e