### PR TITLE
Align mobile menu button left and adjust menu colors

### DIFF
--- a/about.html
+++ b/about.html
@@ -11,18 +11,18 @@
 <body>
   <header class="bg-[#063d49] text-white">
     <div class="flex items-center justify-between p-4">
-      <div class="w-8"></div>
+      <button id="menu-button" class="sm:hidden" aria-label="Toggle menu">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
       <a href="index.html">
         <picture>
           <source media="(max-width: 600px)" srcset="logo/logo2.png">
           <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
         </picture>
       </a>
-      <button id="menu-button" class="sm:hidden" aria-label="Toggle menu">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-      </button>
+      <div class="w-8"></div>
     </div>
     <div class="border-b-2 border-[#d7c9a9]"></div>
     <nav class="hidden sm:flex justify-center space-x-8 py-4">
@@ -32,13 +32,13 @@
       <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Υπηρεσίες</a>
       <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Επικοινωνία</a>
     </nav>
-    <nav id="mobile-menu" class="sm:hidden fixed top-0 right-0 h-full w-2/3 bg-[#063d49] text-white transform translate-x-full transition-transform duration-300 z-40">
+    <nav id="mobile-menu" class="sm:hidden fixed top-0 right-0 h-full w-2/3 bg-[#d7c9a9] text-[#063d49] transform translate-x-full transition-transform duration-300 z-40">
       <div class="flex flex-col items-center mt-20 space-y-4">
-        <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Αρχική</a>
-        <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Σχετικά με εμάς</a>
-        <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Συλλογή</a>
-        <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Υπηρεσίες</a>
-        <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Επικοινωνία</a>
+        <a href="index.html" class="transition-colors duration-300 hover:text-white">Αρχική</a>
+        <a href="about.html" class="transition-colors duration-300 hover:text-white">Σχετικά με εμάς</a>
+        <a href="gallery.html" class="transition-colors duration-300 hover:text-white">Συλλογή</a>
+        <a href="#services" class="transition-colors duration-300 hover:text-white">Υπηρεσίες</a>
+        <a href="#contact" class="transition-colors duration-300 hover:text-white">Επικοινωνία</a>
       </div>
     </nav>
   </header>

--- a/gallery.html
+++ b/gallery.html
@@ -9,18 +9,18 @@
 <body>
   <header class="bg-[#063d49] text-white">
     <div class="flex items-center justify-between p-4">
-      <div class="w-8"></div>
+      <button id="menu-button" class="sm:hidden" aria-label="Toggle menu">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
       <a href="index.html">
         <picture>
           <source media="(max-width: 600px)" srcset="logo/logo2.png">
           <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
         </picture>
       </a>
-      <button id="menu-button" class="sm:hidden" aria-label="Toggle menu">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-      </button>
+      <div class="w-8"></div>
     </div>
     <div class="border-b-2 border-[#d7c9a9]"></div>
     <nav class="hidden sm:flex justify-center space-x-8 py-4">
@@ -30,13 +30,13 @@
       <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Υπηρεσίες</a>
       <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Επικοινωνία</a>
     </nav>
-    <nav id="mobile-menu" class="sm:hidden fixed top-0 right-0 h-full w-2/3 bg-[#063d49] text-white transform translate-x-full transition-transform duration-300 z-40">
+    <nav id="mobile-menu" class="sm:hidden fixed top-0 right-0 h-full w-2/3 bg-[#d7c9a9] text-[#063d49] transform translate-x-full transition-transform duration-300 z-40">
       <div class="flex flex-col items-center mt-20 space-y-4">
-        <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Αρχική</a>
-        <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Σχετικά με εμάς</a>
-        <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Συλλογή</a>
-        <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Υπηρεσίες</a>
-        <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Επικοινωνία</a>
+        <a href="index.html" class="transition-colors duration-300 hover:text-white">Αρχική</a>
+        <a href="about.html" class="transition-colors duration-300 hover:text-white">Σχετικά με εμάς</a>
+        <a href="gallery.html" class="transition-colors duration-300 hover:text-white">Συλλογή</a>
+        <a href="#services" class="transition-colors duration-300 hover:text-white">Υπηρεσίες</a>
+        <a href="#contact" class="transition-colors duration-300 hover:text-white">Επικοινωνία</a>
       </div>
     </nav>
   </header>

--- a/index.html
+++ b/index.html
@@ -12,18 +12,18 @@
 
   <header class="bg-[#063d49] text-white">
     <div class="flex items-center justify-between p-4">
-      <div class="w-8"></div>
+      <button id="menu-button" class="sm:hidden" aria-label="Toggle menu">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
       <a href="index.html">
         <picture>
           <source media="(max-width: 600px)" srcset="logo/logo2.png">
           <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
         </picture>
       </a>
-      <button id="menu-button" class="sm:hidden" aria-label="Toggle menu">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-      </button>
+      <div class="w-8"></div>
     </div>
     <div class="border-b-2 border-[#d7c9a9]"></div>
     <nav class="hidden sm:flex justify-center space-x-8 py-4">
@@ -33,13 +33,13 @@
       <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Υπηρεσίες</a>
       <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Επικοινωνία</a>
     </nav>
-    <nav id="mobile-menu" class="sm:hidden fixed top-0 right-0 h-full w-2/3 bg-[#063d49] text-white transform translate-x-full transition-transform duration-300 z-40">
+    <nav id="mobile-menu" class="sm:hidden fixed top-0 right-0 h-full w-2/3 bg-[#d7c9a9] text-[#063d49] transform translate-x-full transition-transform duration-300 z-40">
       <div class="flex flex-col items-center mt-20 space-y-4">
-        <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Αρχική</a>
-        <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Σχετικά με εμάς</a>
-        <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Συλλογή</a>
-        <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Υπηρεσίες</a>
-        <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Επικοινωνία</a>
+        <a href="index.html" class="transition-colors duration-300 hover:text-white">Αρχική</a>
+        <a href="about.html" class="transition-colors duration-300 hover:text-white">Σχετικά με εμάς</a>
+        <a href="gallery.html" class="transition-colors duration-300 hover:text-white">Συλλογή</a>
+        <a href="#services" class="transition-colors duration-300 hover:text-white">Υπηρεσίες</a>
+        <a href="#contact" class="transition-colors duration-300 hover:text-white">Επικοινωνία</a>
       </div>
     </nav>
   </header>


### PR DESCRIPTION
## Summary
- left-align the hamburger button on mobile navigation
- restyle mobile menu with #d7c9a9 background and #063d49 text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab6f2bc7a48320ab6839e5833fc675