### PR TITLE
Add social icons to desktop header

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,8 +10,8 @@
 </head>
 <body>
   <header class="bg-[#063d49] text-white">
-    <div class="flex items-center justify-between p-4">
-      <button id="menu-button" class="sm:hidden" aria-label="Toggle menu">
+    <div class="relative flex items-center justify-center p-4">
+      <button id="menu-button" class="sm:hidden absolute left-4 top-1/2 -translate-y-1/2" aria-label="Toggle menu">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
         </svg>
@@ -22,7 +22,14 @@
           <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
         </picture>
       </a>
-      <div class="w-8"></div>
+      <div class="hidden sm:flex space-x-4 absolute right-4 top-1/2 -translate-y-1/2">
+        <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
+          <img src="logo/facebook icon.png" alt="Facebook" class="h-8 w-8 rounded-full bg-white">
+        </a>
+        <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
+          <img src="logo/instagram icon.png" alt="Instagram" class="h-8 w-8 rounded-full bg-white">
+        </a>
+      </div>
     </div>
     <div class="border-b-2 border-[#d7c9a9]"></div>
     <nav class="hidden sm:flex justify-center space-x-8 py-4">

--- a/gallery.html
+++ b/gallery.html
@@ -8,8 +8,8 @@
 </head>
 <body>
   <header class="bg-[#063d49] text-white">
-    <div class="flex items-center justify-between p-4">
-      <button id="menu-button" class="sm:hidden" aria-label="Toggle menu">
+    <div class="relative flex items-center justify-center p-4">
+      <button id="menu-button" class="sm:hidden absolute left-4 top-1/2 -translate-y-1/2" aria-label="Toggle menu">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
         </svg>
@@ -20,7 +20,14 @@
           <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
         </picture>
       </a>
-      <div class="w-8"></div>
+      <div class="hidden sm:flex space-x-4 absolute right-4 top-1/2 -translate-y-1/2">
+        <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
+          <img src="logo/facebook icon.png" alt="Facebook" class="h-8 w-8 rounded-full bg-white">
+        </a>
+        <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
+          <img src="logo/instagram icon.png" alt="Instagram" class="h-8 w-8 rounded-full bg-white">
+        </a>
+      </div>
     </div>
     <div class="border-b-2 border-[#d7c9a9]"></div>
     <nav class="hidden sm:flex justify-center space-x-8 py-4">

--- a/index.html
+++ b/index.html
@@ -11,8 +11,8 @@
 <body>
 
   <header class="bg-[#063d49] text-white">
-    <div class="flex items-center justify-between p-4">
-      <button id="menu-button" class="sm:hidden" aria-label="Toggle menu">
+    <div class="relative flex items-center justify-center p-4">
+      <button id="menu-button" class="sm:hidden absolute left-4 top-1/2 -translate-y-1/2" aria-label="Toggle menu">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
         </svg>
@@ -23,7 +23,14 @@
           <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
         </picture>
       </a>
-      <div class="w-8"></div>
+      <div class="hidden sm:flex space-x-4 absolute right-4 top-1/2 -translate-y-1/2">
+        <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
+          <img src="logo/facebook icon.png" alt="Facebook" class="h-8 w-8 rounded-full bg-white">
+        </a>
+        <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
+          <img src="logo/instagram icon.png" alt="Instagram" class="h-8 w-8 rounded-full bg-white">
+        </a>
+      </div>
     </div>
     <div class="border-b-2 border-[#d7c9a9]"></div>
     <nav class="hidden sm:flex justify-center space-x-8 py-4">


### PR DESCRIPTION
## Summary
- Add Facebook and Instagram links to the desktop header, matching footer URLs
- Style header social icons with white circular backgrounds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab70ca41548320944a5ec5bae25428