### PR TITLE
Add social icons to mobile menu

### DIFF
--- a/about.html
+++ b/about.html
@@ -47,6 +47,14 @@
         <a href="#services" class="transition-colors duration-300 hover:text-white">Υπηρεσίες</a>
         <a href="#contact" class="transition-colors duration-300 hover:text-white">Επικοινωνία</a>
       </div>
+      <div class="absolute bottom-4 left-0 right-0 flex justify-center space-x-4">
+        <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
+          <img src="logo/facebook icon.png" alt="Facebook" class="h-8 w-8 rounded-full border border-black bg-transparent">
+        </a>
+        <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
+          <img src="logo/instagram icon.png" alt="Instagram" class="h-8 w-8 rounded-full border border-black bg-transparent">
+        </a>
+      </div>
     </nav>
   </header>
 

--- a/gallery.html
+++ b/gallery.html
@@ -45,6 +45,14 @@
         <a href="#services" class="transition-colors duration-300 hover:text-white">Υπηρεσίες</a>
         <a href="#contact" class="transition-colors duration-300 hover:text-white">Επικοινωνία</a>
       </div>
+      <div class="absolute bottom-4 left-0 right-0 flex justify-center space-x-4">
+        <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
+          <img src="logo/facebook icon.png" alt="Facebook" class="h-8 w-8 rounded-full border border-black bg-transparent">
+        </a>
+        <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
+          <img src="logo/instagram icon.png" alt="Instagram" class="h-8 w-8 rounded-full border border-black bg-transparent">
+        </a>
+      </div>
     </nav>
   </header>
   <main class="py-8">

--- a/index.html
+++ b/index.html
@@ -48,6 +48,14 @@
         <a href="#services" class="transition-colors duration-300 hover:text-white">Υπηρεσίες</a>
         <a href="#contact" class="transition-colors duration-300 hover:text-white">Επικοινωνία</a>
       </div>
+      <div class="absolute bottom-4 left-0 right-0 flex justify-center space-x-4">
+        <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
+          <img src="logo/facebook icon.png" alt="Facebook" class="h-8 w-8 rounded-full border border-black bg-transparent">
+        </a>
+        <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
+          <img src="logo/instagram icon.png" alt="Instagram" class="h-8 w-8 rounded-full border border-black bg-transparent">
+        </a>
+      </div>
     </nav>
   </header>
 


### PR DESCRIPTION
## Summary
- show Facebook and Instagram icons at bottom of mobile navigation menu
- style icons with black border and transparent background

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab734da6408320bcf3f556dd577f8c