### PR TITLE
feat: set desktop menu text color

### DIFF
--- a/about.html
+++ b/about.html
@@ -26,12 +26,12 @@
       </div>
     </div>
     <div class="border-b-2 border-[#d7c9a9]"></div>
-    <nav class="hidden sm:flex justify-center space-x-8 py-4">
-      <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Αρχική</a>
-      <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Σχετικά με εμάς</a>
-      <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Συλλογή</a>
-      <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Υπηρεσίες</a>
-      <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Επικοινωνία</a>
+    <nav class="hidden sm:flex justify-center space-x-8 py-4 text-[#d7c9a9]">
+      <a href="index.html" class="transition-colors duration-300 hover:text-white">Αρχική</a>
+      <a href="about.html" class="transition-colors duration-300 hover:text-white">Σχετικά με εμάς</a>
+      <a href="gallery.html" class="transition-colors duration-300 hover:text-white">Συλλογή</a>
+      <a href="#services" class="transition-colors duration-300 hover:text-white">Υπηρεσίες</a>
+      <a href="#contact" class="transition-colors duration-300 hover:text-white">Επικοινωνία</a>
     </nav>
     <nav id="mobile-menu" class="sm:hidden fixed top-0 right-0 h-full w-2/3 bg-[#d7c9a9] text-[#063d49] transform translate-x-full transition-transform duration-300 z-40">
       <div class="flex flex-col items-center mt-20 space-y-4">

--- a/gallery.html
+++ b/gallery.html
@@ -24,12 +24,12 @@
       </div>
     </div>
     <div class="border-b-2 border-[#d7c9a9]"></div>
-    <nav class="hidden sm:flex justify-center space-x-8 py-4">
-      <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Αρχική</a>
-      <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Σχετικά με εμάς</a>
-      <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Συλλογή</a>
-      <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Υπηρεσίες</a>
-      <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Επικοινωνία</a>
+    <nav class="hidden sm:flex justify-center space-x-8 py-4 text-[#d7c9a9]">
+      <a href="index.html" class="transition-colors duration-300 hover:text-white">Αρχική</a>
+      <a href="about.html" class="transition-colors duration-300 hover:text-white">Σχετικά με εμάς</a>
+      <a href="gallery.html" class="transition-colors duration-300 hover:text-white">Συλλογή</a>
+      <a href="#services" class="transition-colors duration-300 hover:text-white">Υπηρεσίες</a>
+      <a href="#contact" class="transition-colors duration-300 hover:text-white">Επικοινωνία</a>
     </nav>
     <nav id="mobile-menu" class="sm:hidden fixed top-0 right-0 h-full w-2/3 bg-[#d7c9a9] text-[#063d49] transform translate-x-full transition-transform duration-300 z-40">
       <div class="flex flex-col items-center mt-20 space-y-4">

--- a/index.html
+++ b/index.html
@@ -27,12 +27,12 @@
       </div>
     </div>
     <div class="border-b-2 border-[#d7c9a9]"></div>
-    <nav class="hidden sm:flex justify-center space-x-8 py-4">
-      <a href="index.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Αρχική</a>
-      <a href="about.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Σχετικά με εμάς</a>
-      <a href="gallery.html" class="transition-colors duration-300 hover:text-[#d7c9a9]">Συλλογή</a>
-      <a href="#services" class="transition-colors duration-300 hover:text-[#d7c9a9]">Υπηρεσίες</a>
-      <a href="#contact" class="transition-colors duration-300 hover:text-[#d7c9a9]">Επικοινωνία</a>
+    <nav class="hidden sm:flex justify-center space-x-8 py-4 text-[#d7c9a9]">
+      <a href="index.html" class="transition-colors duration-300 hover:text-white">Αρχική</a>
+      <a href="about.html" class="transition-colors duration-300 hover:text-white">Σχετικά με εμάς</a>
+      <a href="gallery.html" class="transition-colors duration-300 hover:text-white">Συλλογή</a>
+      <a href="#services" class="transition-colors duration-300 hover:text-white">Υπηρεσίες</a>
+      <a href="#contact" class="transition-colors duration-300 hover:text-white">Επικοινωνία</a>
     </nav>
     <nav id="mobile-menu" class="sm:hidden fixed top-0 right-0 h-full w-2/3 bg-[#d7c9a9] text-[#063d49] transform translate-x-full transition-transform duration-300 z-40">
       <div class="flex flex-col items-center mt-20 space-y-4">


### PR DESCRIPTION
## Summary
- use #d7c9a9 for desktop menu links

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab76eaf5b883209f97d21ecbc40e3a