### PR TITLE
Add back-to-top button

### DIFF
--- a/about.html
+++ b/about.html
@@ -51,7 +51,6 @@
       <div class="photo-placeholder" aria-label="Φωτογραφία της Αλεξάνδρας"></div>
     </div>
   </section>
-
   <footer id="contact">
     <div class="footer-column">
       <h4>Στοιχεία Επικοινωνίας</h4>
@@ -85,6 +84,7 @@
       <p>Κυριακή: Κλειστά</p>
     </div>
   </footer>
+  <button id="back-to-top" aria-label="Back to top">&#8593;</button>
   <script>
     const menuButton = document.getElementById('menu-button');
     const mobileMenu = document.getElementById('mobile-menu');
@@ -92,6 +92,21 @@
       menuButton.addEventListener('click', () => {
         mobileMenu.classList.toggle('translate-x-full');
         mobileMenu.classList.toggle('translate-x-0');
+      });
+    }
+
+    const backToTop = document.getElementById('back-to-top');
+    if (backToTop) {
+      window.addEventListener('scroll', () => {
+        if (window.pageYOffset > 200) {
+          backToTop.classList.add('show');
+        } else {
+          backToTop.classList.remove('show');
+        }
+      });
+
+      backToTop.addEventListener('click', () => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
       });
     }
   </script>

--- a/gallery.html
+++ b/gallery.html
@@ -73,6 +73,7 @@
       <p>Κυριακή: Κλειστά</p>
     </div>
   </footer>
+  <button id="back-to-top" aria-label="Back to top">&#8593;</button>
   <script>
     const menuButton = document.getElementById('menu-button');
     const mobileMenu = document.getElementById('mobile-menu');
@@ -80,6 +81,21 @@
       menuButton.addEventListener('click', () => {
         mobileMenu.classList.toggle('translate-x-full');
         mobileMenu.classList.toggle('translate-x-0');
+      });
+    }
+
+    const backToTop = document.getElementById('back-to-top');
+    if (backToTop) {
+      window.addEventListener('scroll', () => {
+        if (window.pageYOffset > 200) {
+          backToTop.classList.add('show');
+        } else {
+          backToTop.classList.remove('show');
+        }
+      });
+
+      backToTop.addEventListener('click', () => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
       });
     }
   </script>

--- a/index.html
+++ b/index.html
@@ -236,6 +236,7 @@
       <p>Κυριακή: Κλειστά</p>
     </div>
   </footer>
+  <button id="back-to-top" aria-label="Back to top">&#8593;</button>
   <script>
     const menuButton = document.getElementById('menu-button');
     const mobileMenu = document.getElementById('mobile-menu');
@@ -327,6 +328,21 @@
       });
       nextReview.addEventListener('click', () => {
         reviewList.scrollBy({ left: scrollAmount(), behavior: 'smooth' });
+      });
+    }
+
+    const backToTop = document.getElementById('back-to-top');
+    if (backToTop) {
+      window.addEventListener('scroll', () => {
+        if (window.pageYOffset > 200) {
+          backToTop.classList.add('show');
+        } else {
+          backToTop.classList.remove('show');
+        }
+      });
+
+      backToTop.addEventListener('click', () => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
       });
     }
   </script>

--- a/style.css
+++ b/style.css
@@ -366,3 +366,25 @@ footer img.logo {
   }
 }
 
+/* Back to Top button */
+#back-to-top {
+  position: fixed;
+  left: 1rem;
+  bottom: 1rem;
+  width: 3rem;
+  height: 3rem;
+  border: none;
+  border-radius: 9999px;
+  background: var(--accent);
+  color: white;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 50;
+}
+
+#back-to-top.show {
+  display: flex;
+}
+


### PR DESCRIPTION
## Summary
- Add a fixed back-to-top button styled for left-side placement
- Include scroll logic on index, about, and gallery pages for smooth scrolling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab7afe25988320ac3cb2ff1f0a447e