### PR TITLE
Fix mobile footer spacing on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -324,6 +324,9 @@ footer {
 .footer-column {
   flex: 1 1 300px;
 }
+.footer-column p:last-child {
+  margin-bottom: 0;
+}
 footer img.logo {
   max-height: 180px;
   margin-bottom: 1rem;
@@ -355,7 +358,7 @@ footer img.logo {
 @media (max-width: 600px) {
   footer {
     flex-direction: column;
-    gap: 1rem;
+    gap: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- remove extra margin below contact info in footer
- eliminate flex gap for mobile footer layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac798e1e4083208091fd950e60e89e