### PR TITLE
Split header into logo and navigation sections

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,19 +10,23 @@
 </head>
 <body>
   <header class="bg-[#063d49] text-white">
-    <div class="max-w-7xl mx-auto px-4 flex items-center justify-between h-16">
-      <a href="index.html">
-        <picture>
-          <source media="(max-width: 600px)" srcset="logo/logo1.png">
-          <img src="logo/logo.png" alt="Pawsh logo" class="h-12">
-        </picture>
-      </a>
+    <div class="border-b border-[#d7c9a9]">
+      <div class="max-w-7xl mx-auto flex justify-center py-4">
+        <a href="index.html">
+          <picture>
+            <source media="(max-width: 600px)" srcset="logo/logo1.png">
+            <img src="logo/logo.png" alt="Pawsh logo" class="h-12">
+          </picture>
+        </a>
+      </div>
+    </div>
+    <div class="relative max-w-7xl mx-auto px-4 h-16 flex items-center justify-center">
       <nav class="hidden sm:flex space-x-6">
         <a href="index.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Αρχική</a>
         <a href="about.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Σχετικά με εμάς</a>
         <a href="gallery.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Συλλογή</a>
       </nav>
-      <button id="menu-button" class="sm:hidden" aria-label="Toggle menu">
+      <button id="menu-button" class="sm:hidden absolute right-4" aria-label="Toggle menu">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
         </svg>

--- a/gallery.html
+++ b/gallery.html
@@ -8,19 +8,23 @@
 </head>
 <body>
   <header class="bg-[#063d49] text-white">
-    <div class="max-w-7xl mx-auto px-4 flex items-center justify-between h-16">
-      <a href="index.html">
-        <picture>
-          <source media="(max-width: 600px)" srcset="logo/logo1.png">
-          <img src="logo/logo.png" alt="Pawsh logo" class="h-12">
-        </picture>
-      </a>
+    <div class="border-b border-[#d7c9a9]">
+      <div class="max-w-7xl mx-auto flex justify-center py-4">
+        <a href="index.html">
+          <picture>
+            <source media="(max-width: 600px)" srcset="logo/logo1.png">
+            <img src="logo/logo.png" alt="Pawsh logo" class="h-12">
+          </picture>
+        </a>
+      </div>
+    </div>
+    <div class="relative max-w-7xl mx-auto px-4 h-16 flex items-center justify-center">
       <nav class="hidden sm:flex space-x-6">
         <a href="index.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Αρχική</a>
         <a href="about.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Σχετικά με εμάς</a>
         <a href="gallery.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Συλλογή</a>
       </nav>
-      <button id="menu-button" class="sm:hidden" aria-label="Toggle menu">
+      <button id="menu-button" class="sm:hidden absolute right-4" aria-label="Toggle menu">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
         </svg>

--- a/index.html
+++ b/index.html
@@ -10,19 +10,23 @@
 </head>
   <body>
     <header class="bg-[#063d49] text-white">
-      <div class="max-w-7xl mx-auto px-4 flex items-center justify-between h-16">
-        <a href="index.html">
-          <picture>
-            <source media="(max-width: 600px)" srcset="logo/logo1.png">
-            <img src="logo/logo.png" alt="Pawsh logo" class="h-12">
-          </picture>
-        </a>
+      <div class="border-b border-[#d7c9a9]">
+        <div class="max-w-7xl mx-auto flex justify-center py-4">
+          <a href="index.html">
+            <picture>
+              <source media="(max-width: 600px)" srcset="logo/logo1.png">
+              <img src="logo/logo.png" alt="Pawsh logo" class="h-12">
+            </picture>
+          </a>
+        </div>
+      </div>
+      <div class="relative max-w-7xl mx-auto px-4 h-16 flex items-center justify-center">
         <nav class="hidden sm:flex space-x-6">
           <a href="index.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Αρχική</a>
           <a href="about.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Σχετικά με εμάς</a>
           <a href="gallery.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Συλλογή</a>
         </nav>
-        <button id="menu-button" class="sm:hidden" aria-label="Toggle menu">
+        <button id="menu-button" class="sm:hidden absolute right-4" aria-label="Toggle menu">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
           </svg>

--- a/style.css
+++ b/style.css
@@ -18,39 +18,7 @@ a {
 }
 header {
   background: var(--accent);
-  padding: 1rem;
-  display: flex;
-  justify-content: center;
-  align-items: center;
   color: white;
-  position: relative;
-}
-header img.logo {
-  max-height: 300px;
-  max-width: 300px;
-}
-
-@media (max-width: 600px) {
-  header {
-    justify-content: center;
-  }
-}
-
-.header-socials {
-  position: absolute;
-  right: 1rem;
-  top: 50%;
-  transform: translateY(-50%);
-  display: flex;
-  gap: 0.5rem;
-}
-
-.header-socials a img {
-  width: 36px;
-  height: 36px;
-  background: white;
-  border-radius: 50%;
-  padding: 3px;
 }
 
 section {


### PR DESCRIPTION
## Summary
- Divide header with #d7c9a9 line and center logo above navigation links
- Remove conflicting global header styles to support stacked layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acaa8671308320844fad59d7faf860