### PR TITLE
Place mobile menu button before logo

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,23 +10,23 @@
 </head>
 <body>
   <header class="bg-[#063d49] text-white">
-    <div class="max-w-7xl mx-auto px-4 flex items-center justify-between h-16">
+    <div class="max-w-7xl mx-auto px-4 flex items-center justify-start sm:justify-between h-16">
+      <button id="menu-button" class="sm:hidden mr-4" aria-label="Toggle menu">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
       <a href="index.html">
         <picture>
           <source media="(max-width: 600px)" srcset="logo/logo1.png">
           <img src="logo/logo.png" alt="Pawsh logo" class="h-12">
         </picture>
       </a>
-      <nav class="hidden sm:flex space-x-6">
+      <nav class="hidden sm:flex space-x-6 ml-auto">
         <a href="index.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Αρχική</a>
         <a href="about.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Σχετικά με εμάς</a>
         <a href="gallery.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Συλλογή</a>
       </nav>
-      <button id="menu-button" class="sm:hidden" aria-label="Toggle menu">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-      </button>
     </div>
     <nav id="mobile-menu" class="sm:hidden fixed top-0 right-0 h-full w-2/3 bg-[#d7c9a9] text-[#063d49] transform translate-x-full transition-transform duration-300 z-40">
       <div class="flex flex-col items-center mt-20 space-y-4">

--- a/gallery.html
+++ b/gallery.html
@@ -8,23 +8,23 @@
 </head>
 <body>
   <header class="bg-[#063d49] text-white">
-    <div class="max-w-7xl mx-auto px-4 flex items-center justify-between h-16">
+    <div class="max-w-7xl mx-auto px-4 flex items-center justify-start sm:justify-between h-16">
+      <button id="menu-button" class="sm:hidden mr-4" aria-label="Toggle menu">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
       <a href="index.html">
         <picture>
           <source media="(max-width: 600px)" srcset="logo/logo1.png">
           <img src="logo/logo.png" alt="Pawsh logo" class="h-12">
         </picture>
       </a>
-      <nav class="hidden sm:flex space-x-6">
+      <nav class="hidden sm:flex space-x-6 ml-auto">
         <a href="index.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Αρχική</a>
         <a href="about.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Σχετικά με εμάς</a>
         <a href="gallery.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Συλλογή</a>
       </nav>
-      <button id="menu-button" class="sm:hidden" aria-label="Toggle menu">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-      </button>
     </div>
     <nav id="mobile-menu" class="sm:hidden fixed top-0 right-0 h-full w-2/3 bg-[#d7c9a9] text-[#063d49] transform translate-x-full transition-transform duration-300 z-40">
       <div class="flex flex-col items-center mt-20 space-y-4">

--- a/index.html
+++ b/index.html
@@ -10,23 +10,23 @@
 </head>
   <body>
     <header class="bg-[#063d49] text-white">
-      <div class="max-w-7xl mx-auto px-4 flex items-center justify-between h-16">
+      <div class="max-w-7xl mx-auto px-4 flex items-center justify-start sm:justify-between h-16">
+        <button id="menu-button" class="sm:hidden mr-4" aria-label="Toggle menu">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
         <a href="index.html">
           <picture>
             <source media="(max-width: 600px)" srcset="logo/logo1.png">
             <img src="logo/logo.png" alt="Pawsh logo" class="h-12">
           </picture>
         </a>
-        <nav class="hidden sm:flex space-x-6">
+        <nav class="hidden sm:flex space-x-6 ml-auto">
           <a href="index.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Αρχική</a>
           <a href="about.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Σχετικά με εμάς</a>
           <a href="gallery.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Συλλογή</a>
         </nav>
-        <button id="menu-button" class="sm:hidden" aria-label="Toggle menu">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-          </svg>
-        </button>
       </div>
       <nav id="mobile-menu" class="sm:hidden fixed top-0 right-0 h-full w-2/3 bg-[#d7c9a9] text-[#063d49] transform translate-x-full transition-transform duration-300 z-40">
         <div class="flex flex-col items-center mt-20 space-y-4">


### PR DESCRIPTION
## Summary
- Move hamburger menu button before logo and left-align header on mobile
- Preserve desktop navigation placement with responsive flex classes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acaac72dc08320a513212913272133