### PR TITLE
Fix mobile header with left hamburger button

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,6 +10,18 @@
 </head>
 <body>
   <header class="bg-[#063d49] text-white">
+    <div class="flex items-center justify-between p-4">
+      <div class="flex items-center space-x-2">
+        <button id="menu-button" class="sm:hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]" aria-label="Toggle menu">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+        <a href="index.html">
+          <img src="logo/logo2.png" alt="Pawsh logo" class="h-10">
+        </a>
+      </div>
+      <nav class="hidden sm:flex space-x-4">
         <a href="index.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Αρχική</a>
         <a href="about.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Σχετικά με εμάς</a>
         <a href="gallery.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Συλλογή</a>

--- a/gallery.html
+++ b/gallery.html
@@ -8,6 +8,18 @@
 </head>
 <body>
   <header class="bg-[#063d49] text-white">
+    <div class="flex items-center justify-between p-4">
+      <div class="flex items-center space-x-2">
+        <button id="menu-button" class="sm:hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]" aria-label="Toggle menu">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+        <a href="index.html">
+          <img src="logo/logo2.png" alt="Pawsh logo" class="h-10">
+        </a>
+      </div>
+      <nav class="hidden sm:flex space-x-4">
         <a href="index.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Αρχική</a>
         <a href="about.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Σχετικά με εμάς</a>
         <a href="gallery.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Συλλογή</a>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,18 @@
 </head>
   <body>
     <header class="bg-[#063d49] text-white">
+      <div class="flex items-center justify-between p-4">
+        <div class="flex items-center space-x-2">
+          <button id="menu-button" class="sm:hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]" aria-label="Toggle menu">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          </button>
+          <a href="index.html">
+            <img src="logo/logo2.png" alt="Pawsh logo" class="h-10">
+          </a>
+        </div>
+        <nav class="hidden sm:flex space-x-4">
           <a href="index.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Αρχική</a>
           <a href="about.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Σχετικά με εμάς</a>
           <a href="gallery.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Συλλογή</a>


### PR DESCRIPTION
## Summary
- Rebuild site header for mobile with a hamburger toggle positioned to the left of the logo
- Preserve desktop navigation while introducing responsive mobile menu across all main pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acad8f4e9483208d7c9c3aff3f0acd