### PR TITLE
Revamp header layout with centered logo and social icons

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,12 +9,17 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-
+    <header class="bg-[#063d49] text-white">
+      <div class="relative flex items-center justify-center py-4 border-b border-[#d7c9a9]">
+        <a href="index.html">
+          <img src="logo/logo2.png" alt="Pawsh logo" class="h-16">
+        </a>
+        <div class="absolute right-4 flex space-x-2">
           <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
-            <img src="logo/facebook icon.png" alt="Facebook" class="h-8 w-8 rounded-full">
+            <img src="logo/facebook icon.png" alt="Facebook" class="w-8 h-8 rounded-full">
           </a>
           <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
-            <img src="logo/instagram icon.png" alt="Instagram" class="h-8 w-8 rounded-full">
+            <img src="logo/instagram icon.png" alt="Instagram" class="w-8 h-8 rounded-full">
           </a>
         </div>
       </div>

--- a/gallery.html
+++ b/gallery.html
@@ -7,12 +7,17 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-
+    <header class="bg-[#063d49] text-white">
+      <div class="relative flex items-center justify-center py-4 border-b border-[#d7c9a9]">
+        <a href="index.html">
+          <img src="logo/logo2.png" alt="Pawsh logo" class="h-16">
+        </a>
+        <div class="absolute right-4 flex space-x-2">
           <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
-            <img src="logo/facebook icon.png" alt="Facebook" class="h-8 w-8 rounded-full">
+            <img src="logo/facebook icon.png" alt="Facebook" class="w-8 h-8 rounded-full">
           </a>
           <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
-            <img src="logo/instagram icon.png" alt="Instagram" class="h-8 w-8 rounded-full">
+            <img src="logo/instagram icon.png" alt="Instagram" class="w-8 h-8 rounded-full">
           </a>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,18 @@
 </head>
   <body>
     <header class="bg-[#063d49] text-white">
-
+      <div class="relative flex items-center justify-center py-4 border-b border-[#d7c9a9]">
+        <a href="index.html">
+          <img src="logo/logo2.png" alt="Pawsh logo" class="h-16">
+        </a>
+        <div class="absolute right-4 flex space-x-2">
+          <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
+            <img src="logo/facebook icon.png" alt="Facebook" class="w-8 h-8 rounded-full">
+          </a>
+          <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
+            <img src="logo/instagram icon.png" alt="Instagram" class="w-8 h-8 rounded-full">
+          </a>
+        </div>
       </div>
       <nav class="flex justify-center space-x-6 py-2">
         <a href="index.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Αρχική</a>

--- a/style.css
+++ b/style.css
@@ -21,6 +21,10 @@ header {
   color: white;
 }
 
+header nav a {
+  color: white;
+}
+
 section {
   padding: 4rem 1rem;
   max-width: 960px;


### PR DESCRIPTION
## Summary
- Split header into top logo/social strip and bottom navigation, separated by a #d7c9a9 line.
- Centered Pawsh logo with right-aligned circular Facebook and Instagram links across main pages.
- Ensured navigation links render in white via new CSS rule.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acb14985408320984d0d02ce647679