### PR TITLE
Invert header navigation colors

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,9 +10,9 @@
 </head>
 <body>
   <header class="bg-[#063d49] text-white">
-        <a href="index.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Αρχική</a>
-        <a href="about.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Σχετικά με εμάς</a>
-        <a href="gallery.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Συλλογή</a>
+        <a href="index.html" class="px-3 py-2 rounded text-[#d7c9a9] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white">Αρχική</a>
+        <a href="about.html" class="px-3 py-2 rounded text-[#d7c9a9] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white">Σχετικά με εμάς</a>
+        <a href="gallery.html" class="px-3 py-2 rounded text-[#d7c9a9] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white">Συλλογή</a>
       </nav>
     </div>
     <nav id="mobile-menu" class="sm:hidden fixed top-0 right-0 h-full w-2/3 bg-[#d7c9a9] text-[#063d49] transform translate-x-full transition-transform duration-300 z-40">

--- a/gallery.html
+++ b/gallery.html
@@ -8,9 +8,9 @@
 </head>
 <body>
   <header class="bg-[#063d49] text-white">
-        <a href="index.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Αρχική</a>
-        <a href="about.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Σχετικά με εμάς</a>
-        <a href="gallery.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Συλλογή</a>
+        <a href="index.html" class="px-3 py-2 rounded text-[#d7c9a9] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white">Αρχική</a>
+        <a href="about.html" class="px-3 py-2 rounded text-[#d7c9a9] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white">Σχετικά με εμάς</a>
+        <a href="gallery.html" class="px-3 py-2 rounded text-[#d7c9a9] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white">Συλλογή</a>
       </nav>
     </div>
     <nav id="mobile-menu" class="sm:hidden fixed top-0 right-0 h-full w-2/3 bg-[#d7c9a9] text-[#063d49] transform translate-x-full transition-transform duration-300 z-40">

--- a/index.html
+++ b/index.html
@@ -10,9 +10,9 @@
 </head>
   <body>
     <header class="bg-[#063d49] text-white">
-          <a href="index.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Αρχική</a>
-          <a href="about.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Σχετικά με εμάς</a>
-          <a href="gallery.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Συλλογή</a>
+          <a href="index.html" class="px-3 py-2 rounded text-[#d7c9a9] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white">Αρχική</a>
+          <a href="about.html" class="px-3 py-2 rounded text-[#d7c9a9] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white">Σχετικά με εμάς</a>
+          <a href="gallery.html" class="px-3 py-2 rounded text-[#d7c9a9] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white">Συλλογή</a>
         </nav>
       </div>
       <nav id="mobile-menu" class="sm:hidden fixed top-0 right-0 h-full w-2/3 bg-[#d7c9a9] text-[#063d49] transform translate-x-full transition-transform duration-300 z-40">


### PR DESCRIPTION
## Summary
- make navigation links default to #d7c9a9
- switch navigation links to white on hover and focus ring

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acad4864f48320ab7219555df4a2e5