### PR TITLE
Implement responsive header with social links and mobile menu

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,7 +9,12 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-
+  <header class="bg-[#063d49] text-white">
+    <!-- Desktop header -->
+    <div class="hidden md:block">
+      <div class="flex items-center justify-center relative py-2 border-b border-[#d7c9a9]">
+        <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
+        <div class="absolute right-4 flex space-x-2">
           <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
             <img src="logo/facebook icon.png" alt="Facebook" class="w-8 h-8 rounded-full">
           </a>
@@ -19,11 +24,40 @@
         </div>
       </div>
       <nav class="flex justify-center space-x-6 py-2">
-        <a href="index.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Αρχική</a>
-        <a href="about.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Σχετικά με εμάς</a>
-        <a href="gallery.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Συλλογή</a>
+        <a href="index.html" class="text-[#d7c9a9] hover:underline">Αρχική</a>
+        <a href="about.html" class="text-[#d7c9a9] hover:underline">Σχετικά με Εμάς</a>
+        <a href="gallery.html" class="text-[#d7c9a9] hover:underline">Gallery</a>
       </nav>
-    </header>
+    </div>
+
+    <!-- Mobile header -->
+    <div class="flex items-center justify-between px-4 py-2 md:hidden">
+      <button id="menu-button" class="text-white text-3xl focus:outline-none">&#9776;</button>
+      <img src="logo/logo1.png" alt="Pawsh logo" class="h-12 mx-auto">
+      <div class="w-8"></div>
+    </div>
+  </header>
+
+  <!-- Mobile menu -->
+  <div id="mobile-menu" class="fixed top-0 left-0 w-64 h-full bg-[#d7c9a9] text-[#063d49] transform -translate-x-full transition-transform duration-300 z-50 flex flex-col p-6 md:hidden">
+    <nav class="flex flex-col space-y-4">
+      <a href="index.html">Αρχική</a>
+      <a href="about.html">Σχετικά με Εμάς</a>
+      <a href="gallery.html">Gallery</a>
+    </nav>
+    <div class="mt-auto flex flex-col items-center space-y-4">
+      <a href="https://pawshpetbeautysalon.setmore.com" class="btn" target="_blank" rel="noopener">Κλείσε Ραντεβού</a>
+      <p>Τηλέφωνο: 2104404084</p>
+      <div class="flex space-x-4">
+        <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
+          <img src="logo/facebook icon.png" alt="Facebook" class="w-8 h-8 rounded-full">
+        </a>
+        <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
+          <img src="logo/instagram icon.png" alt="Instagram" class="w-8 h-8 rounded-full">
+        </a>
+      </div>
+    </div>
+  </div>
 
   <section class="about-section">
     <div class="about-text">
@@ -74,7 +108,7 @@
     const mobileMenu = document.getElementById('mobile-menu');
     if (menuButton && mobileMenu) {
       menuButton.addEventListener('click', () => {
-        mobileMenu.classList.toggle('translate-x-full');
+        mobileMenu.classList.toggle('-translate-x-full');
         mobileMenu.classList.toggle('translate-x-0');
       });
     }

--- a/gallery.html
+++ b/gallery.html
@@ -7,7 +7,12 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-
+  <header class="bg-[#063d49] text-white">
+    <!-- Desktop header -->
+    <div class="hidden md:block">
+      <div class="flex items-center justify-center relative py-2 border-b border-[#d7c9a9]">
+        <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
+        <div class="absolute right-4 flex space-x-2">
           <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
             <img src="logo/facebook icon.png" alt="Facebook" class="w-8 h-8 rounded-full">
           </a>
@@ -17,11 +22,41 @@
         </div>
       </div>
       <nav class="flex justify-center space-x-6 py-2">
-        <a href="index.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Αρχική</a>
-        <a href="about.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Σχετικά με εμάς</a>
-        <a href="gallery.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Συλλογή</a>
+        <a href="index.html" class="text-[#d7c9a9] hover:underline">Αρχική</a>
+        <a href="about.html" class="text-[#d7c9a9] hover:underline">Σχετικά με Εμάς</a>
+        <a href="gallery.html" class="text-[#d7c9a9] hover:underline">Gallery</a>
       </nav>
-    </header>
+    </div>
+
+    <!-- Mobile header -->
+    <div class="flex items-center justify-between px-4 py-2 md:hidden">
+      <button id="menu-button" class="text-white text-3xl focus:outline-none">&#9776;</button>
+      <img src="logo/logo1.png" alt="Pawsh logo" class="h-12 mx-auto">
+      <div class="w-8"></div>
+    </div>
+  </header>
+
+  <!-- Mobile menu -->
+  <div id="mobile-menu" class="fixed top-0 left-0 w-64 h-full bg-[#d7c9a9] text-[#063d49] transform -translate-x-full transition-transform duration-300 z-50 flex flex-col p-6 md:hidden">
+    <nav class="flex flex-col space-y-4">
+      <a href="index.html">Αρχική</a>
+      <a href="about.html">Σχετικά με Εμάς</a>
+      <a href="gallery.html">Gallery</a>
+    </nav>
+    <div class="mt-auto flex flex-col items-center space-y-4">
+      <a href="https://pawshpetbeautysalon.setmore.com" class="btn" target="_blank" rel="noopener">Κλείσε Ραντεβού</a>
+      <p>Τηλέφωνο: 2104404084</p>
+      <div class="flex space-x-4">
+        <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
+          <img src="logo/facebook icon.png" alt="Facebook" class="w-8 h-8 rounded-full">
+        </a>
+        <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
+          <img src="logo/instagram icon.png" alt="Instagram" class="w-8 h-8 rounded-full">
+        </a>
+      </div>
+    </div>
+  </div>
+
   <main class="py-8">
   </main>
   <footer id="contact">
@@ -63,7 +98,7 @@
     const mobileMenu = document.getElementById('mobile-menu');
     if (menuButton && mobileMenu) {
       menuButton.addEventListener('click', () => {
-        mobileMenu.classList.toggle('translate-x-full');
+        mobileMenu.classList.toggle('-translate-x-full');
         mobileMenu.classList.toggle('translate-x-0');
       });
     }

--- a/index.html
+++ b/index.html
@@ -10,15 +10,54 @@
 </head>
   <body>
     <header class="bg-[#063d49] text-white">
+      <!-- Desktop header -->
+      <div class="hidden md:block">
+        <div class="flex items-center justify-center relative py-2 border-b border-[#d7c9a9]">
+          <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
+          <div class="absolute right-4 flex space-x-2">
+            <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
+              <img src="logo/facebook icon.png" alt="Facebook" class="w-8 h-8 rounded-full">
+            </a>
+            <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
+              <img src="logo/instagram icon.png" alt="Instagram" class="w-8 h-8 rounded-full">
+            </a>
+          </div>
+        </div>
+        <nav class="flex justify-center space-x-6 py-2">
+          <a href="index.html" class="text-[#d7c9a9] hover:underline">Αρχική</a>
+          <a href="about.html" class="text-[#d7c9a9] hover:underline">Σχετικά με Εμάς</a>
+          <a href="gallery.html" class="text-[#d7c9a9] hover:underline">Gallery</a>
+        </nav>
+      </div>
 
+      <!-- Mobile header -->
+      <div class="flex items-center justify-between px-4 py-2 md:hidden">
+        <button id="menu-button" class="text-white text-3xl focus:outline-none">&#9776;</button>
+        <img src="logo/logo1.png" alt="Pawsh logo" class="h-12 mx-auto">
+        <div class="w-8"></div>
+      </div>
+    </header>
+
+    <!-- Mobile menu -->
+    <div id="mobile-menu" class="fixed top-0 left-0 w-64 h-full bg-[#d7c9a9] text-[#063d49] transform -translate-x-full transition-transform duration-300 z-50 flex flex-col p-6 md:hidden">
+      <nav class="flex flex-col space-y-4">
+        <a href="index.html">Αρχική</a>
+        <a href="about.html">Σχετικά με Εμάς</a>
+        <a href="gallery.html">Gallery</a>
+      </nav>
+      <div class="mt-auto flex flex-col items-center space-y-4">
+        <a href="https://pawshpetbeautysalon.setmore.com" class="btn" target="_blank" rel="noopener">Κλείσε Ραντεβού</a>
+        <p>Τηλέφωνο: 2104404084</p>
+        <div class="flex space-x-4">
+          <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
+            <img src="logo/facebook icon.png" alt="Facebook" class="w-8 h-8 rounded-full">
+          </a>
+          <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
+            <img src="logo/instagram icon.png" alt="Instagram" class="w-8 h-8 rounded-full">
+          </a>
         </div>
       </div>
-      <nav class="flex justify-center space-x-6 py-2">
-        <a href="index.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Αρχική</a>
-        <a href="about.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Σχετικά με εμάς</a>
-        <a href="gallery.html" class="px-3 py-2 rounded hover:text-[#d7c9a9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d7c9a9]">Συλλογή</a>
-      </nav>
-    </header>
+    </div>
 
   <section class="hero">
     <h1>Καλώς ήρθες στο Pawsh</h1>
@@ -205,7 +244,7 @@
     const mobileMenu = document.getElementById('mobile-menu');
     if (menuButton && mobileMenu) {
       menuButton.addEventListener('click', () => {
-        mobileMenu.classList.toggle('translate-x-full');
+        mobileMenu.classList.toggle('-translate-x-full');
         mobileMenu.classList.toggle('translate-x-0');
       });
     }


### PR DESCRIPTION
## Summary
- Add two-tier desktop header with centered logo, right-aligned social icons and #d7c9a9 navigation links
- Introduce mobile hamburger header and slide-out menu with CTA, phone and social icons
- Apply unified header across index, about and gallery pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acbed8319083208102827a5d1fb57f