### PR TITLE
Slide mobile menu in from the right

### DIFF
--- a/about.html
+++ b/about.html
@@ -39,7 +39,7 @@
   </header>
 
   <!-- Mobile menu -->
-  <div id="mobile-menu" class="fixed top-0 left-0 w-64 h-full bg-[#d7c9a9] text-[#063d49] transform -translate-x-full transition-transform duration-300 z-50 flex flex-col p-6 md:hidden">
+  <div id="mobile-menu" class="fixed top-0 right-0 w-64 h-full bg-[#d7c9a9] text-[#063d49] transform translate-x-full transition-transform duration-300 z-50 flex flex-col p-6 md:hidden">
     <nav class="flex flex-col space-y-4">
       <a href="index.html">Αρχική</a>
       <a href="about.html">Σχετικά με Εμάς</a>
@@ -108,7 +108,7 @@
     const mobileMenu = document.getElementById('mobile-menu');
     if (menuButton && mobileMenu) {
       menuButton.addEventListener('click', () => {
-        mobileMenu.classList.toggle('-translate-x-full');
+        mobileMenu.classList.toggle('translate-x-full');
         mobileMenu.classList.toggle('translate-x-0');
       });
     }

--- a/gallery.html
+++ b/gallery.html
@@ -37,7 +37,7 @@
   </header>
 
   <!-- Mobile menu -->
-  <div id="mobile-menu" class="fixed top-0 left-0 w-64 h-full bg-[#d7c9a9] text-[#063d49] transform -translate-x-full transition-transform duration-300 z-50 flex flex-col p-6 md:hidden">
+  <div id="mobile-menu" class="fixed top-0 right-0 w-64 h-full bg-[#d7c9a9] text-[#063d49] transform translate-x-full transition-transform duration-300 z-50 flex flex-col p-6 md:hidden">
     <nav class="flex flex-col space-y-4">
       <a href="index.html">Αρχική</a>
       <a href="about.html">Σχετικά με Εμάς</a>
@@ -98,7 +98,7 @@
     const mobileMenu = document.getElementById('mobile-menu');
     if (menuButton && mobileMenu) {
       menuButton.addEventListener('click', () => {
-        mobileMenu.classList.toggle('-translate-x-full');
+        mobileMenu.classList.toggle('translate-x-full');
         mobileMenu.classList.toggle('translate-x-0');
       });
     }

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
     </header>
 
     <!-- Mobile menu -->
-    <div id="mobile-menu" class="fixed top-0 left-0 w-64 h-full bg-[#d7c9a9] text-[#063d49] transform -translate-x-full transition-transform duration-300 z-50 flex flex-col p-6 md:hidden">
+    <div id="mobile-menu" class="fixed top-0 right-0 w-64 h-full bg-[#d7c9a9] text-[#063d49] transform translate-x-full transition-transform duration-300 z-50 flex flex-col p-6 md:hidden">
       <nav class="flex flex-col space-y-4">
         <a href="index.html">Αρχική</a>
         <a href="about.html">Σχετικά με Εμάς</a>
@@ -244,7 +244,7 @@
     const mobileMenu = document.getElementById('mobile-menu');
     if (menuButton && mobileMenu) {
       menuButton.addEventListener('click', () => {
-        mobileMenu.classList.toggle('-translate-x-full');
+        mobileMenu.classList.toggle('translate-x-full');
         mobileMenu.classList.toggle('translate-x-0');
       });
     }


### PR DESCRIPTION
## Summary
- Move mobile navigation drawer to the right side of the screen
- Update toggle logic to slide menu in/out from the right

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acc0de98e8832095b4f42d730b9b57