### PR TITLE
Make header logo link to home page

### DIFF
--- a/about.html
+++ b/about.html
@@ -13,7 +13,7 @@
     <!-- Desktop header -->
     <div class="hidden md:block">
       <div class="flex items-center justify-center relative py-2 border-b border-[#d7c9a9]">
-        <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
+        <a href="index.html" class="mx-auto"><img src="logo/logo.png" alt="Pawsh logo" class="h-16"></a>
         <div class="absolute right-4 flex space-x-2">
           <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
             <img src="logo/facebook icon.png" alt="Facebook" class="w-8 h-8 rounded-full">
@@ -33,7 +33,7 @@
     <!-- Mobile header -->
     <div class="flex items-center justify-between px-4 py-2 md:hidden">
       <button id="menu-button" class="text-white text-3xl focus:outline-none">&#9776;</button>
-      <img src="logo/logo1.png" alt="Pawsh logo" class="h-12 mx-auto">
+      <a href="index.html" class="mx-auto"><img src="logo/logo1.png" alt="Pawsh logo" class="h-12"></a>
       <div class="w-8"></div>
     </div>
   </header>

--- a/gallery.html
+++ b/gallery.html
@@ -11,7 +11,7 @@
     <!-- Desktop header -->
     <div class="hidden md:block">
       <div class="flex items-center justify-center relative py-2 border-b border-[#d7c9a9]">
-        <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
+        <a href="index.html" class="mx-auto"><img src="logo/logo.png" alt="Pawsh logo" class="h-16"></a>
         <div class="absolute right-4 flex space-x-2">
           <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
             <img src="logo/facebook icon.png" alt="Facebook" class="w-8 h-8 rounded-full">
@@ -31,7 +31,7 @@
     <!-- Mobile header -->
     <div class="flex items-center justify-between px-4 py-2 md:hidden">
       <button id="menu-button" class="text-white text-3xl focus:outline-none">&#9776;</button>
-      <img src="logo/logo1.png" alt="Pawsh logo" class="h-12 mx-auto">
+      <a href="index.html" class="mx-auto"><img src="logo/logo1.png" alt="Pawsh logo" class="h-12"></a>
       <div class="w-8"></div>
     </div>
   </header>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
       <!-- Desktop header -->
       <div class="hidden md:block">
         <div class="flex items-center justify-center relative py-2 border-b border-[#d7c9a9]">
-          <img src="logo/logo.png" alt="Pawsh logo" class="h-16 mx-auto">
+          <a href="index.html" class="mx-auto"><img src="logo/logo.png" alt="Pawsh logo" class="h-16"></a>
           <div class="absolute right-4 flex space-x-2">
             <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
               <img src="logo/facebook icon.png" alt="Facebook" class="w-8 h-8 rounded-full">
@@ -33,7 +33,7 @@
       <!-- Mobile header -->
       <div class="flex items-center justify-between px-4 py-2 md:hidden">
         <button id="menu-button" class="text-white text-3xl focus:outline-none">&#9776;</button>
-        <img src="logo/logo1.png" alt="Pawsh logo" class="h-12 mx-auto">
+        <a href="index.html" class="mx-auto"><img src="logo/logo1.png" alt="Pawsh logo" class="h-12"></a>
         <div class="w-8"></div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- Wrap desktop and mobile header logos in anchors to navigate back to the index page on click.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acc20cb5a88320a6fbd106d2c4c0bf