### PR TITLE
Make gallery boxes square and empty

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -62,74 +62,38 @@
     <div class="space-y-8 max-w-5xl mx-auto">
       <!-- Row 1 -->
       <div class="grid grid-cols-2 gap-4">
-        <div class="relative paw-box p-4 rounded-lg">
-          <img src="dogs/dog1.jpg" alt="Πριν 1" class="w-full h-48 object-cover rounded-lg">
-          <span class="absolute bottom-2 left-2 bg-[#063d49] text-white text-xs px-2 py-1 rounded">Πριν</span>
-        </div>
-        <div class="relative paw-box p-4 rounded-lg">
-          <img src="dogs/dog2.jpg" alt="Μετά 1" class="w-full h-48 object-cover rounded-lg">
-          <span class="absolute bottom-2 left-2 bg-[#063d49] text-white text-xs px-2 py-1 rounded">Μετά</span>
-        </div>
+        <div class="relative paw-box p-4 rounded-lg"></div>
+        <div class="relative paw-box p-4 rounded-lg"></div>
       </div>
 
       <!-- Row 2 -->
       <div class="grid grid-cols-2 gap-4">
-        <div class="relative paw-box p-4 rounded-lg">
-          <img src="dogs/dog3.jpg" alt="Πριν 2" class="w-full h-48 object-cover rounded-lg">
-          <span class="absolute bottom-2 left-2 bg-[#063d49] text-white text-xs px-2 py-1 rounded">Πριν</span>
-        </div>
-        <div class="relative paw-box p-4 rounded-lg">
-          <img src="dogs/dog4.jpg" alt="Μετά 2" class="w-full h-48 object-cover rounded-lg">
-          <span class="absolute bottom-2 left-2 bg-[#063d49] text-white text-xs px-2 py-1 rounded">Μετά</span>
-        </div>
+        <div class="relative paw-box p-4 rounded-lg"></div>
+        <div class="relative paw-box p-4 rounded-lg"></div>
       </div>
 
       <!-- Row 3 -->
       <div class="grid grid-cols-2 gap-4">
-        <div class="relative paw-box p-4 rounded-lg">
-          <img src="dogs/dog5.jpg" alt="Πριν 3" class="w-full h-48 object-cover rounded-lg">
-          <span class="absolute bottom-2 left-2 bg-[#063d49] text-white text-xs px-2 py-1 rounded">Πριν</span>
-        </div>
-        <div class="relative paw-box p-4 rounded-lg">
-          <img src="dogs/dog6.jpg" alt="Μετά 3" class="w-full h-48 object-cover rounded-lg">
-          <span class="absolute bottom-2 left-2 bg-[#063d49] text-white text-xs px-2 py-1 rounded">Μετά</span>
-        </div>
+        <div class="relative paw-box p-4 rounded-lg"></div>
+        <div class="relative paw-box p-4 rounded-lg"></div>
       </div>
 
       <!-- Row 4 -->
       <div class="grid grid-cols-2 gap-4">
-        <div class="relative paw-box p-4 rounded-lg">
-          <img src="dogs/dog7.jpg" alt="Πριν 4" class="w-full h-48 object-cover rounded-lg">
-          <span class="absolute bottom-2 left-2 bg-[#063d49] text-white text-xs px-2 py-1 rounded">Πριν</span>
-        </div>
-        <div class="relative paw-box p-4 rounded-lg">
-          <img src="dogs/dog8.jpg" alt="Μετά 4" class="w-full h-48 object-cover rounded-lg">
-          <span class="absolute bottom-2 left-2 bg-[#063d49] text-white text-xs px-2 py-1 rounded">Μετά</span>
-        </div>
+        <div class="relative paw-box p-4 rounded-lg"></div>
+        <div class="relative paw-box p-4 rounded-lg"></div>
       </div>
 
       <!-- Row 5 -->
       <div class="grid grid-cols-2 gap-4">
-        <div class="relative paw-box p-4 rounded-lg">
-          <img src="Pawsh%20pet%20salon/Pawsh%20pet%20salon%201.jpg" alt="Πριν 5" class="w-full h-48 object-cover rounded-lg">
-          <span class="absolute bottom-2 left-2 bg-[#063d49] text-white text-xs px-2 py-1 rounded">Πριν</span>
-        </div>
-        <div class="relative paw-box p-4 rounded-lg">
-          <img src="Pawsh%20pet%20salon/Pawsh%20pet%20salon%202.jpg" alt="Μετά 5" class="w-full h-48 object-cover rounded-lg">
-          <span class="absolute bottom-2 left-2 bg-[#063d49] text-white text-xs px-2 py-1 rounded">Μετά</span>
-        </div>
+        <div class="relative paw-box p-4 rounded-lg"></div>
+        <div class="relative paw-box p-4 rounded-lg"></div>
       </div>
 
       <!-- Row 6 -->
       <div class="grid grid-cols-2 gap-4">
-        <div class="relative paw-box p-4 rounded-lg">
-          <img src="Pawsh%20pet%20salon/Pawsh%20pet%20salon%203.jpg" alt="Πριν 6" class="w-full h-48 object-cover rounded-lg">
-          <span class="absolute bottom-2 left-2 bg-[#063d49] text-white text-xs px-2 py-1 rounded">Πριν</span>
-        </div>
-        <div class="relative paw-box p-4 rounded-lg">
-          <img src="Pawsh%20pet%20salon/Pawsh%20pet%20salon%204.jpg" alt="Μετά 6" class="w-full h-48 object-cover rounded-lg">
-          <span class="absolute bottom-2 left-2 bg-[#063d49] text-white text-xs px-2 py-1 rounded">Μετά</span>
-        </div>
+        <div class="relative paw-box p-4 rounded-lg"></div>
+        <div class="relative paw-box p-4 rounded-lg"></div>
       </div>
     </div>
   </main>

--- a/style.css
+++ b/style.css
@@ -372,6 +372,7 @@ footer img.logo {
   background-repeat: repeat;
   transition: transform 0.3s ease;
   overflow: hidden;
+  aspect-ratio: 1 / 1;
 }
 
 .paw-box:hover {


### PR DESCRIPTION
## Summary
- Ensure gallery boxes are square using CSS aspect-ratio
- Remove all images from gallery placeholders while keeping hover scale effect

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68accc6c161883208a4f69dd9d8c6580