### PR TITLE
feat: add paw print background to gallery

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -6,7 +6,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
+<body class="gallery-paw-bg">
   <header class="bg-[#063d49] text-white">
     <!-- Desktop header -->
     <div class="hidden md:block">

--- a/style.css
+++ b/style.css
@@ -367,11 +367,20 @@ footer img.logo {
 /* Paw background boxes for gallery */
 .paw-box {
   background-color: #fff;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' fill='%23063d49'%3E%3Ccircle cx='9' cy='7' r='3'/%3E%3Ccircle cx='23' cy='7' r='3'/%3E%3Ccircle cx='16' cy='3' r='3'/%3E%3Ccircle cx='7' cy='19' r='3'/%3E%3Ccircle cx='25' cy='19' r='3'/%3E%3Cpath d='M16 10c-6 0-9 4-9 8s3 8 9 8 9-4 9-8-3-8-9-8z'/%3E%3C/svg%3E");
+  color: #063d49;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' fill='currentColor'%3E%3Ccircle cx='9' cy='7' r='3'/%3E%3Ccircle cx='23' cy='7' r='3'/%3E%3Ccircle cx='16' cy='3' r='3'/%3E%3Ccircle cx='7' cy='19' r='3'/%3E%3Ccircle cx='25' cy='19' r='3'/%3E%3Cpath d='M16 10c-6 0-9 4-9 8s3 8 9 8 9-4 9-8-3-8-9-8z'/%3E%3C/svg%3E");
   background-size: 30px 30px;
   background-repeat: repeat;
   transition: transform 0.3s ease;
   overflow: hidden;
+}
+
+/* Paw print background for gallery page */
+.gallery-paw-bg {
+  color: #063d49;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 96 96' fill='currentColor'%3E%3Cg transform='translate(32 32)'%3E%3Ccircle cx='9' cy='7' r='3'/%3E%3Ccircle cx='23' cy='7' r='3'/%3E%3Ccircle cx='16' cy='3' r='3'/%3E%3Ccircle cx='7' cy='19' r='3'/%3E%3Ccircle cx='25' cy='19' r='3'/%3E%3Cpath d='M16 10c-6 0-9 4-9 8s3 8 9 8 9-4 9-8-3-8-9-8z'/%3E%3C/g%3E%3C/svg%3E");
+  background-repeat: repeat;
+  background-size: 200px 200px;
 }
 
 .paw-box:hover {


### PR DESCRIPTION
## Summary
- add reusable `.gallery-paw-bg` pattern using inline paw print SVG
- apply pattern to gallery page body
- ensure paw print color uses accent #063d49
- shrink paw prints and increase spacing for a subtler pattern

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68accbc04dd08320b84b0f931de1cb44