### PR TITLE
Add web app icons and theme color

### DIFF
--- a/about.html
+++ b/about.html
@@ -7,6 +7,13 @@
   <title>Σχετικά με εμάς - Pawsh Pet Salon</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="style.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png">
+  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png">
+  <meta name="theme-color" content="#063d49">
 </head>
 <body>
   <header class="bg-[#063d49] text-white">

--- a/gallery.html
+++ b/gallery.html
@@ -5,6 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="style.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png">
+  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png">
+  <meta name="theme-color" content="#063d49">
 </head>
 <body class="gallery-paw-bg">
   <header class="bg-[#063d49] text-white">

--- a/index.html
+++ b/index.html
@@ -7,6 +7,13 @@
   <title>Pawsh - Pet Beauty Salon</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="style.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png">
+  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png">
+  <meta name="theme-color" content="#063d49">
 </head>
   <body>
     <header class="bg-[#063d49] text-white">

--- a/privacy.html
+++ b/privacy.html
@@ -4,6 +4,13 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Πολιτική Απορρήτου - Pawsh Pet Salon</title>
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png">
+  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png">
+  <meta name="theme-color" content="#063d49">
   <style>
     body { font-family: 'Segoe UI', sans-serif; margin: 2rem; line-height: 1.6; }
     h1 { color: #063d49; }

--- a/terms.html
+++ b/terms.html
@@ -4,6 +4,13 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Όροι και Προϋποθέσεις - Pawsh Pet Salon</title>
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png">
+  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png">
+  <meta name="theme-color" content="#063d49">
   <style>
     body { font-family: 'Segoe UI', sans-serif; margin: 2rem; line-height: 1.6; }
     h1 { color: #063d49; }


### PR DESCRIPTION
## Summary
- include Apple touch icon, favicon links, manifest, and theme color in head of all HTML pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b07f5a5d6883209ee4018d902a85eb