### PR TITLE
Add canonical link tag to HTML head

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Μάθετε περισσότερα για την ομάδα του Pawsh Pet Salon">
   <title>Σχετικά με εμάς - Pawsh Pet Salon</title>
+  <link rel="canonical" href="https://www.pawsh.gr/">
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="style.css">
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/gallery.html
+++ b/gallery.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="canonical" href="https://www.pawsh.gr/">
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="style.css">
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Pet grooming salon in Galatsi offering professional services">
   <title>Pawsh - Pet Beauty Salon</title>
+  <link rel="canonical" href="https://www.pawsh.gr/">
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="style.css">
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/privacy.html
+++ b/privacy.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Πολιτική Απορρήτου - Pawsh Pet Salon</title>
+  <link rel="canonical" href="https://www.pawsh.gr/">
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">

--- a/terms.html
+++ b/terms.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Όροι και Προϋποθέσεις - Pawsh Pet Salon</title>
+  <link rel="canonical" href="https://www.pawsh.gr/">
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">


### PR DESCRIPTION
## Summary
- add canonical link to head sections of index, about, gallery, privacy and terms pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1bc2025448320893b34162ac9b7e3