### PR TITLE
Remove hero tagline from landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,6 @@
 
   <section class="hero">
     <h1>Καλώς ήρθες στο Pawsh</h1>
-    <p> Pet beauty salon στο Γαλάτσι. Λαμπερό τρίχωμα και χουζούρεμα εγγυημένα!</p>
     <a href="https://pawshpetbeautysalon.setmore.com" class="btn" target="_blank" rel="noopener">Κλείσε Ραντεβού</a>
   </section>
 


### PR DESCRIPTION
## Summary
- remove marketing tagline from hero section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1fa38f044832086e3c4c8603ad795