### PR TITLE
Use contain sizing for hero background

### DIFF
--- a/style.css
+++ b/style.css
@@ -33,25 +33,26 @@ section {
 h1, h2 {
   color: var(--accent);
 }
-.hero {
-  background: url('Pawsh pet salon/Pawsh pet salon 1.jpg');
-  background-size: cover;
-  background-repeat: no-repeat;
-  background-position: center;
-  text-align: center;
-  padding: 4rem 1rem;
-  color: white;
-  width: 100%;
-  max-width: none;
-  margin: 0;
-  min-height: 600px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  position: relative;
-  overflow: visible;
-}
+  .hero {
+    background: url('Pawsh pet salon/Pawsh pet salon 1.jpg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-color: black;
+    text-align: center;
+    padding: 4rem 1rem;
+    color: white;
+    width: 100%;
+    max-width: none;
+    margin: 0;
+    min-height: 600px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+    overflow: visible;
+  }
 .hero h1,
 .hero p {
   background-color: rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
## Summary
- ensure hero section uses `background-size: contain` with centered, non-repeating image
- set hero background color to black to avoid white margins

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1fe6e2e30832088737d0dedc78c57