### PR TITLE
Make home gallery images square

### DIFF
--- a/style.css
+++ b/style.css
@@ -385,4 +385,6 @@ footer img.logo {
 .gallery-carousel img {
   border-radius: 12px;
   margin-right: 10px;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
 }


### PR DESCRIPTION
## Summary
- Ensure home page gallery images always render as squares using CSS aspect ratio and object-fit.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b706c1c56c8320846e583ee3f4ee9b