### PR TITLE
Shrink gallery paw icon size

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -91,10 +91,10 @@
         </div>
       </div>
       <button id="prev" class="absolute top-1/2 left-4 -translate-y-1/2 bg-[#063d49] p-2 rounded-full">
-        <img src="logo/paw.svg" alt="Previous slide" class="w-4 h-4">
+        <img src="logo/paw.svg" alt="Previous slide" class="w-3 h-3">
       </button>
       <button id="next" class="absolute top-1/2 right-4 -translate-y-1/2 bg-[#063d49] p-2 rounded-full">
-        <img src="logo/paw.svg" alt="Next slide" class="w-4 h-4">
+        <img src="logo/paw.svg" alt="Next slide" class="w-3 h-3">
       </button>
     </div>
   </main>


### PR DESCRIPTION
## Summary
- Reduce paw.svg navigation icons on gallery page to 75% size for a less obtrusive look

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b721ec95a483208c8677dc465a837f