### PR TITLE
Fix homepage gallery slider paths and responsive styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,20 +112,20 @@
     <!-- Κύριος slider -->
     <div class="swiper doghouse-main">
       <div class="swiper-wrapper">
-        <div class="swiper-slide dog-slide"><img src="dog1.png"  alt="Σκύλος 1"  loading="lazy"></div>
-        <div class="swiper-slide dog-slide"><img src="dog2.png"  alt="Σκύλος 2"  loading="lazy"></div>
-        <div class="swiper-slide dog-slide"><img src="dog3.png"  alt="Σκύλος 3"  loading="lazy"></div>
-        <div class="swiper-slide dog-slide"><img src="dog4.png"  alt="Σκύλος 4"  loading="lazy"></div>
-        <div class="swiper-slide dog-slide"><img src="dog5.png"  alt="Σκύλος 5"  loading="lazy"></div>
-        <div class="swiper-slide dog-slide"><img src="dog6.png"  alt="Σκύλος 6"  loading="lazy"></div>
-        <div class="swiper-slide dog-slide"><img src="dog7.png"  alt="Σκύλος 7"  loading="lazy"></div>
-        <div class="swiper-slide dog-slide"><img src="dog8.png"  alt="Σκύλος 8"  loading="lazy"></div>
-        <div class="swiper-slide dog-slide"><img src="dog9.png"  alt="Σκύλος 9"  loading="lazy"></div>
-        <div class="swiper-slide dog-slide"><img src="dog10.png" alt="Σκύλος 10" loading="lazy"></div>
-        <div class="swiper-slide dog-slide"><img src="dog11.png" alt="Σκύλος 11" loading="lazy"></div>
-        <div class="swiper-slide dog-slide"><img src="dog12.png" alt="Σκύλος 12" loading="lazy"></div>
-        <div class="swiper-slide dog-slide"><img src="dog13.png" alt="Σκύλος 13" loading="lazy"></div>
-        <div class="swiper-slide dog-slide"><img src="dog14.png" alt="Σκύλος 14" loading="lazy"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog1.jpg"  alt="Σκύλος 1"  loading="lazy"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog2.jpg"  alt="Σκύλος 2"  loading="lazy"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog3.jpg"  alt="Σκύλος 3"  loading="lazy"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog4.jpg"  alt="Σκύλος 4"  loading="lazy"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog5.jpg"  alt="Σκύλος 5"  loading="lazy"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog6.png"  alt="Σκύλος 6"  loading="lazy"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog7.png"  alt="Σκύλος 7"  loading="lazy"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog8.png"  alt="Σκύλος 8"  loading="lazy"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog9.png"  alt="Σκύλος 9"  loading="lazy"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog10.png" alt="Σκύλος 10" loading="lazy"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog11.png" alt="Σκύλος 11" loading="lazy"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog12.png" alt="Σκύλος 12" loading="lazy"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog13.png" alt="Σκύλος 13" loading="lazy"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog14.png" alt="Σκύλος 14" loading="lazy"></div>
       </div>
 
       <!-- Πλοήγηση -->
@@ -139,20 +139,20 @@
     <!-- Thumbnails -->
     <div class="swiper doghouse-thumbs" aria-hidden="false">
       <div class="swiper-wrapper">
-        <div class="swiper-slide"><img src="dog1.png"  alt=""></div>
-        <div class="swiper-slide"><img src="dog2.png"  alt=""></div>
-        <div class="swiper-slide"><img src="dog3.png"  alt=""></div>
-        <div class="swiper-slide"><img src="dog4.png"  alt=""></div>
-        <div class="swiper-slide"><img src="dog5.png"  alt=""></div>
-        <div class="swiper-slide"><img src="dog6.png"  alt=""></div>
-        <div class="swiper-slide"><img src="dog7.png"  alt=""></div>
-        <div class="swiper-slide"><img src="dog8.png"  alt=""></div>
-        <div class="swiper-slide"><img src="dog9.png"  alt=""></div>
-        <div class="swiper-slide"><img src="dog10.png" alt=""></div>
-        <div class="swiper-slide"><img src="dog11.png" alt=""></div>
-        <div class="swiper-slide"><img src="dog12.png" alt=""></div>
-        <div class="swiper-slide"><img src="dog13.png" alt=""></div>
-        <div class="swiper-slide"><img src="dog14.png" alt=""></div>
+        <div class="swiper-slide"><img src="dogs/dog1.jpg"  alt=""></div>
+        <div class="swiper-slide"><img src="dogs/dog2.jpg"  alt=""></div>
+        <div class="swiper-slide"><img src="dogs/dog3.jpg"  alt=""></div>
+        <div class="swiper-slide"><img src="dogs/dog4.jpg"  alt=""></div>
+        <div class="swiper-slide"><img src="dogs/dog5.jpg"  alt=""></div>
+        <div class="swiper-slide"><img src="dogs/dog6.png"  alt=""></div>
+        <div class="swiper-slide"><img src="dogs/dog7.png"  alt=""></div>
+        <div class="swiper-slide"><img src="dogs/dog8.png"  alt=""></div>
+        <div class="swiper-slide"><img src="dogs/dog9.png"  alt=""></div>
+        <div class="swiper-slide"><img src="dogs/dog10.png" alt=""></div>
+        <div class="swiper-slide"><img src="dogs/dog11.png" alt=""></div>
+        <div class="swiper-slide"><img src="dogs/dog12.png" alt=""></div>
+        <div class="swiper-slide"><img src="dogs/dog13.png" alt=""></div>
+        <div class="swiper-slide"><img src="dogs/dog14.png" alt=""></div>
       </div>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -379,3 +379,42 @@ footer img.logo {
   aspect-ratio: 1 / 1;
   object-fit: cover;
 }
+
+/* Swiper gallery on homepage */
+.doghouse-gallery-wrap {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 0;
+}
+
+.doghouse-main {
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.doghouse-main img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.doghouse-thumbs {
+  margin-top: 1rem;
+}
+
+.doghouse-thumbs .swiper-slide {
+  width: 80px;
+  height: 80px;
+  opacity: 0.4;
+}
+
+.doghouse-thumbs .swiper-slide-thumb-active {
+  opacity: 1;
+}
+
+.doghouse-thumbs img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 8px;
+}


### PR DESCRIPTION
## Summary
- Corrected image paths for homepage Swiper gallery to load dog images from `dogs/` directory
- Added responsive styling for Swiper slider and thumbnails to support swipe on mobile and desktop

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b76b71a42c8320a6e39ae979598fca