### PR TITLE
Restrict homepage gallery to desktop 600x600 layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,30 +109,30 @@
       <a href="https://pawshpetbeautysalon.setmore.com" class="btn" target="_blank" rel="noopener">Κλείσε Ραντεβού</a>
     </section>
 
-<section id="gallery" class="doghouse-gallery-wrap" aria-label="Gallery σκύλων">
+<section id="gallery" class="doghouse-gallery-wrap hidden md:block" aria-label="Gallery σκύλων">
   <div class="wood-frame">
 
     <!-- Κύριος slider -->
     <div class="swiper doghouse-main">
       <div class="swiper-wrapper">
-        <div class="swiper-slide dog-slide"><img src="dogs/dog1.jpg"  alt="Σκύλος 1"  loading="lazy" width="800" height="800"></div>
-        <div class="swiper-slide dog-slide"><img src="dogs/dog2.jpg"  alt="Σκύλος 2"  loading="lazy" width="800" height="800"></div>
-        <div class="swiper-slide dog-slide"><img src="dogs/dog3.jpg"  alt="Σκύλος 3"  loading="lazy" width="800" height="800"></div>
-        <div class="swiper-slide dog-slide"><img src="dogs/dog4.jpg"  alt="Σκύλος 4"  loading="lazy" width="800" height="800"></div>
-        <div class="swiper-slide dog-slide"><img src="dogs/dog5.jpg"  alt="Σκύλος 5"  loading="lazy" width="800" height="800"></div>
-        <div class="swiper-slide dog-slide"><img src="dogs/dog6.png"  alt="Σκύλος 6"  loading="lazy" width="800" height="800"></div>
-        <div class="swiper-slide dog-slide"><img src="dogs/dog7.png"  alt="Σκύλος 7"  loading="lazy" width="800" height="800"></div>
-        <div class="swiper-slide dog-slide"><img src="dogs/dog8.png"  alt="Σκύλος 8"  loading="lazy" width="800" height="800"></div>
-        <div class="swiper-slide dog-slide"><img src="dogs/dog9.png"  alt="Σκύλος 9"  loading="lazy" width="800" height="800"></div>
-        <div class="swiper-slide dog-slide"><img src="dogs/dog10.png" alt="Σκύλος 10" loading="lazy" width="800" height="800"></div>
-        <div class="swiper-slide dog-slide"><img src="dogs/dog11.png" alt="Σκύλος 11" loading="lazy" width="800" height="800"></div>
-        <div class="swiper-slide dog-slide"><img src="dogs/dog12.png" alt="Σκύλος 12" loading="lazy" width="800" height="800"></div>
-        <div class="swiper-slide dog-slide"><img src="dogs/dog13.png" alt="Σκύλος 13" loading="lazy" width="800" height="800"></div>
-        <div class="swiper-slide dog-slide"><img src="dogs/dog14.png" alt="Σκύλος 14" loading="lazy" width="800" height="800"></div>
-        <div class="swiper-slide dog-slide"><img src="dogs/dog15.jpg" alt="Σκύλος 15" loading="lazy" width="800" height="800"></div>
-        <div class="swiper-slide dog-slide"><img src="dogs/dog16.jpg" alt="Σκύλος 16" loading="lazy" width="800" height="800"></div>
-        <div class="swiper-slide dog-slide"><img src="dogs/dog17.jpg" alt="Σκύλος 17" loading="lazy" width="800" height="800"></div>
-        <div class="swiper-slide dog-slide"><img src="dogs/dog18.jpg" alt="Σκύλος 18" loading="lazy" width="800" height="800"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog1.jpg"  alt="Σκύλος 1"  loading="lazy" width="600" height="600"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog2.jpg"  alt="Σκύλος 2"  loading="lazy" width="600" height="600"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog3.jpg"  alt="Σκύλος 3"  loading="lazy" width="600" height="600"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog4.jpg"  alt="Σκύλος 4"  loading="lazy" width="600" height="600"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog5.jpg"  alt="Σκύλος 5"  loading="lazy" width="600" height="600"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog6.png"  alt="Σκύλος 6"  loading="lazy" width="600" height="600"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog7.png"  alt="Σκύλος 7"  loading="lazy" width="600" height="600"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog8.png"  alt="Σκύλος 8"  loading="lazy" width="600" height="600"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog9.png"  alt="Σκύλος 9"  loading="lazy" width="600" height="600"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog10.png" alt="Σκύλος 10" loading="lazy" width="600" height="600"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog11.png" alt="Σκύλος 11" loading="lazy" width="600" height="600"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog12.png" alt="Σκύλος 12" loading="lazy" width="600" height="600"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog13.png" alt="Σκύλος 13" loading="lazy" width="600" height="600"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog14.png" alt="Σκύλος 14" loading="lazy" width="600" height="600"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog15.jpg" alt="Σκύλος 15" loading="lazy" width="600" height="600"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog16.jpg" alt="Σκύλος 16" loading="lazy" width="600" height="600"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog17.jpg" alt="Σκύλος 17" loading="lazy" width="600" height="600"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog18.jpg" alt="Σκύλος 18" loading="lazy" width="600" height="600"></div>
       </div>
 
       <!-- Πλοήγηση -->
@@ -174,7 +174,7 @@
 <div class="lightbox" id="lightbox" aria-hidden="true" role="dialog" aria-label="Προβολή εικόνας">
   <button class="lb-close" id="lbClose" aria-label="Κλείσιμο">✕</button>
   <button class="lb-prev" id="lbPrev" aria-label="Προηγούμενη">❮</button>
-  <img id="lbImg" alt="" width="800" height="800">
+  <img id="lbImg" alt="" width="600" height="600">
   <button class="lb-next" id="lbNext" aria-label="Επόμενη">❯</button>
 </div>
 

--- a/style.css
+++ b/style.css
@@ -418,3 +418,25 @@ footer img.logo {
   object-fit: cover;
   border-radius: 8px;
 }
+
+/* Desktop-only gallery sizing */
+@media (max-width: 767px) {
+  #gallery {
+    display: none;
+  }
+}
+
+@media (min-width: 768px) {
+  .doghouse-gallery-wrap {
+    max-width: 600px;
+  }
+  .doghouse-main {
+    width: 600px;
+    height: 600px;
+  }
+  .doghouse-main img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}


### PR DESCRIPTION
## Summary
- Hide homepage gallery on small screens and constrain it to 600x600 on desktop
- Set gallery images and lightbox to 600x600

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b86e5782848320b6e8ec9118fae363