### PR TITLE
Fix stray image beneath homepage gallery

### DIFF
--- a/style.css
+++ b/style.css
@@ -436,6 +436,53 @@ footer img.logo {
   border-radius: 8px;
 }
 
+/* Lightbox overlay */
+.lightbox {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.8);
+  z-index: 1000;
+}
+
+.lightbox.open {
+  display: flex;
+}
+
+.lightbox img {
+  max-width: 90%;
+  max-height: 90%;
+  border-radius: 8px;
+}
+
+.lightbox button {
+  position: absolute;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 2rem;
+  cursor: pointer;
+}
+
+.lb-close {
+  top: 1rem;
+  right: 1rem;
+}
+
+.lb-prev {
+  left: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.lb-next {
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
 /* Desktop-only gallery sizing */
 @media (max-width: 767px) {
   #gallery {


### PR DESCRIPTION
## Summary
- Add lightbox overlay styles to hide placeholder image under gallery
- Style navigation buttons for lightbox display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b872488e448320a634cc99ad78d80b