### PR TITLE
Adjust hero images for 1920x1440

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,15 +74,15 @@
   <section class="hero">
     <div class="swiper hero-swiper">
       <div class="swiper-wrapper">
-        <div class="swiper-slide"><img src="Pawsh pet salon/Pawsh pet salon1.jpg" alt="Salon photo 1" loading="lazy"></div>
-        <div class="swiper-slide"><img src="Pawsh pet salon/Pawsh pet salon2.jpg" alt="Salon photo 2" loading="lazy"></div>
-        <div class="swiper-slide"><img src="Pawsh pet salon/Pawsh pet salon3.jpg" alt="Salon photo 3" loading="lazy"></div>
-        <div class="swiper-slide"><img src="Pawsh pet salon/Pawsh pet salon4.jpg" alt="Salon photo 4" loading="lazy"></div>
-        <div class="swiper-slide"><img src="Pawsh pet salon/Pawsh pet salon5.jpg" alt="Salon photo 5" loading="lazy"></div>
-        <div class="swiper-slide"><img src="Pawsh pet salon/Pawsh pet salon6.jpg" alt="Salon photo 6" loading="lazy"></div>
-        <div class="swiper-slide"><img src="Pawsh pet salon/Pawsh pet salon7.jpg" alt="Salon photo 7" loading="lazy"></div>
-        <div class="swiper-slide"><img src="Pawsh pet salon/Pawsh pet salon8.jpg" alt="Salon photo 8" loading="lazy"></div>
-        <div class="swiper-slide"><img src="Pawsh pet salon/Pawsh pet salon9.jpg" alt="Salon photo 9" loading="lazy"></div>
+        <div class="swiper-slide"><img src="Pawsh pet salon/Pawsh pet salon1.jpg" alt="Salon photo 1" loading="lazy" width="1920" height="1440"></div>
+        <div class="swiper-slide"><img src="Pawsh pet salon/Pawsh pet salon2.jpg" alt="Salon photo 2" loading="lazy" width="1920" height="1440"></div>
+        <div class="swiper-slide"><img src="Pawsh pet salon/Pawsh pet salon3.jpg" alt="Salon photo 3" loading="lazy" width="1920" height="1440"></div>
+        <div class="swiper-slide"><img src="Pawsh pet salon/Pawsh pet salon4.jpg" alt="Salon photo 4" loading="lazy" width="1920" height="1440"></div>
+        <div class="swiper-slide"><img src="Pawsh pet salon/Pawsh pet salon5.jpg" alt="Salon photo 5" loading="lazy" width="1920" height="1440"></div>
+        <div class="swiper-slide"><img src="Pawsh pet salon/Pawsh pet salon6.jpg" alt="Salon photo 6" loading="lazy" width="1920" height="1440"></div>
+        <div class="swiper-slide"><img src="Pawsh pet salon/Pawsh pet salon7.jpg" alt="Salon photo 7" loading="lazy" width="1920" height="1440"></div>
+        <div class="swiper-slide"><img src="Pawsh pet salon/Pawsh pet salon8.jpg" alt="Salon photo 8" loading="lazy" width="1920" height="1440"></div>
+        <div class="swiper-slide"><img src="Pawsh pet salon/Pawsh pet salon9.jpg" alt="Salon photo 9" loading="lazy" width="1920" height="1440"></div>
       </div>
       <div class="swiper-pagination"></div>
     </div>

--- a/style.css
+++ b/style.css
@@ -42,7 +42,7 @@ h1, h2 {
   width: 100%;
   max-width: none;
   margin: 0;
-  min-height: 600px;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
## Summary
- Set hero section to span full viewport height for better display on 1920x1440 screens.
- Added explicit 1920x1440 dimensions to hero slider images for consistent rendering.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b872bd7118832098df681b7c797338