### PR TITLE
Add philosophy section to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,6 +92,25 @@
     <a href="https://pawshpetbeautysalon.setmore.com" class="btn" target="_blank" rel="noopener">Κλείσε Ραντεβού</a>
   </section>
 
+  <section id="philosophy" class="philosophy">
+    <div class="philosophy-content">
+      <div class="philosophy-text">
+        <h2>Η Φιλοσοφία μας</h2>
+        <p>Η φιλοσοφία του Pawsh στηρίζεται στην αγάπη για τα ζώα και στην πεποίθηση ότι ο καλλωπισμός είναι κάτι παραπάνω από περιποίηση: είναι μέρος της ευεξίας και της καθημερινής φροντίδας τους.</p>
+        <p>Για εμάς, κάθε σκύλος είναι ξεχωριστός. Δημιουργούμε ένα φιλικό και θετικό περιβάλλον, όπου συνδυάζουμε:</p>
+        <ul>
+          <li>Εξειδικευμένη γνώση και συνεχή εκπαίδευση.</li>
+          <li>Ασφαλή, ποιοτικά προϊόντα.</li>
+          <li>Υπομονή, σεβασμό και θετική προσέγγιση.</li>
+        </ul>
+        <p>Στόχος μας είναι κάθε επίσκεψη στο Pawsh να είναι μια ευχάριστη εμπειρία τόσο για τον σκύλο όσο και για τον κηδεμόνα του.</p>
+      </div>
+      <div class="philosophy-image">
+        <div class="photo-placeholder" aria-label="Φωτογραφία"></div>
+      </div>
+    </div>
+  </section>
+
     <section id="services" class="services">
       <h2>Οι Υπηρεσίες μας</h2>
       <p class="services-intro">Επαγγελματικές υπηρεσίες καλλωπισμού προσαρμοσμένες στις ανάγκες του κατοικίδιού σας</p>

--- a/style.css
+++ b/style.css
@@ -98,13 +98,45 @@ h1, h2 {
   font-weight: bold;
   transition: background 0.3s ease, color 0.3s ease;
 }
-.btn:hover, .sticky-cta:hover {
-  background: white;
-  color: var(--accent);
-}
-.services {
-  text-align: center;
-}
+  .btn:hover, .sticky-cta:hover {
+    background: white;
+    color: var(--accent);
+  }
+
+  .philosophy-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2rem;
+  }
+
+  .philosophy-text {
+    flex: 1;
+  }
+
+  .philosophy-image {
+    flex: 1;
+    width: 100%;
+    max-width: 400px;
+  }
+
+  .photo-placeholder {
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    background: #e2e2e2;
+    border: 4px solid var(--accent);
+    border-radius: 8px;
+  }
+
+  @media (min-width: 768px) {
+    .philosophy-content {
+      flex-direction: row;
+    }
+  }
+
+  .services {
+    text-align: center;
+  }
 
 .services h2 {
   font-size: 1.75rem;


### PR DESCRIPTION
## Summary
- add philosophy section with Greek copy and bullet list under hero
- include placeholder image and responsive flex layout
- style new section and placeholder in CSS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b87f2e09a48320ac125e88ab3f39c8