### PR TITLE
Fix hero slider visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -51,12 +51,18 @@ h1, h2 {
   overflow: hidden;
 }
 
+/* Ensure the Swiper container and slides fill the hero section */
 .hero-swiper,
 .hero-swiper .swiper-slide {
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
+  height: 100%;
+}
+
+/* Allow the wrapper to occupy space so images become visible */
+.hero-swiper .swiper-wrapper {
   height: 100%;
 }
 


### PR DESCRIPTION
## Summary
- prevent hero Swiper wrapper from collapsing so images appear

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b88bf9e62c8320affcecc747ed1cb3