### PR TITLE
feat: restyle hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,10 +86,11 @@
       </div>
       <div class="swiper-pagination"></div>
     </div>
-    <h1>Καλώς ήρθες στο Pawsh</h1>
-    
-    <h2>For posh paws!</h2>
-    <a href="https://pawshpetbeautysalon.setmore.com" class="btn" target="_blank" rel="noopener">Κλείσε Ραντεβού</a>
+    <div class="hero-content">
+      <h1>Καλώς ήρθες στο Pawsh</h1>
+      <h2>For posh paws!</h2>
+      <a href="https://pawshpetbeautysalon.setmore.com" class="btn" target="_blank" rel="noopener">Κλείσε Ραντεβού</a>
+    </div>
   </section>
 
   <section id="philosophy" class="philosophy">

--- a/style.css
+++ b/style.css
@@ -35,19 +35,18 @@ h1, h2 {
 }
 
 .hero {
-  background-color: #d7c9a9;
-  text-align: center;
-  padding: 4rem 1rem;
-  color: white;
-  width: 100%;
-  max-width: none;
-  margin: 0;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
   position: relative;
+  width: 100%;
+  height: 70vh;
+  min-height: 70vh;
+  margin: 0;
+  padding: 0;
+  max-width: none;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
   overflow: hidden;
 }
 
@@ -78,20 +77,33 @@ h1, h2 {
   height: 100%;
   object-fit: cover;
 }
-.hero h1,
-.hero h2,
-.hero p {
-  background-color: rgba(0, 0, 0, 0.5);
-  display: inline-block;
-  padding: 0.5rem 1rem;
-  border-radius: 10px;
-  color: white;
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom, rgba(0,0,0,0.3), rgba(0,0,0,0.6));
+  z-index: 1;
 }
 
-/* Ensure hero content remains on top */
-.hero > * {
+.hero-content {
   position: relative;
-  z-index: 1;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 0 1rem;
+}
+
+.hero-content h1,
+.hero-content h2 {
+  margin: 0;
+  color: white;
+  text-shadow: 0 2px 4px rgba(0,0,0,0.6);
+}
+
+.hero-content .btn {
+  text-shadow: 0 1px 2px rgba(0,0,0,0.5);
 }
 .logo {
   max-width: 150px;


### PR DESCRIPTION
## Summary
- Wrap hero heading, subtitle and CTA in `.hero-content` overlay
- Make hero 70vh full-width background with dark gradient overlay
- Add text shadows for readability and keep CTA above images

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf177623c88320bd09f10ad72b7d68