### PR TITLE
Link hero CTA to Setmore

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
     <div class="hero-content">
       <h1>Καλώς ήρθες στο Pawsh</h1>
       <h2>For posh paws!</h2>
-      <a href="#contact" class="hero-cta" aria-label="Κλείσε Ραντεβού">Κλείσε Ραντεβού</a>
+      <a href="https://pawshpetbeautysalon.setmore.com" class="hero-cta" aria-label="Κλείσε Ραντεβού" target="_blank" rel="noopener">Κλείσε Ραντεβού</a>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- Update hero section CTA to link directly to Pawsh's Setmore booking page and open in a new tab.

## Testing
- `npm test` *(fails: command not found; Node/npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5797ddc588320a0f027be7247232c