### PR TITLE
Add spacing above CTA buttons in services and reviews sections

### DIFF
--- a/style.css
+++ b/style.css
@@ -146,6 +146,12 @@ h1, h2 {
   font-weight: bold;
   color: var(--accent);
 }
+
+/* Ensure CTA buttons in services and reviews have space from previous content */
+.services .hero-cta,
+.reviews .hero-cta {
+  margin-top: 1rem;
+}
 .faq {
   max-width: 960px;
   margin: auto;


### PR DESCRIPTION
## Summary
- Add margin-top to hero-cta buttons in services and reviews so they no longer touch the elements above.

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c58661a464832096abdc0dba418bb4