### PR TITLE
Enhance SEO metadata on About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,8 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Μάθετε περισσότερα για την ομάδα του Pawsh Pet Salon">
-  <title>The Story - Pawsh Pet Salon</title>
+  <meta name="title" content="Η Ιστορία μας – Pawsh Pet Grooming">
+  <meta name="description" content="Γνωρίστε την Αλεξάνδρα, την ψυχή πίσω από το Pawsh. Από chef σε επαγγελματία pet groomer, με αγάπη για τα ζώα.">
+  <meta name="keywords" content="Σχετικά με εμάς, ιστορία Pawsh, Αλεξάνδρα, θετική προσέγγιση σκύλων, pet grooming ιστορία">
+  <meta name="author" content="Pawsh Pet Grooming">
+  <meta name="robots" content="index, follow">
+  <title>Η Ιστορία μας – Pawsh Pet Grooming</title>
   <link rel="canonical" href="https://www.pawsh.gr/">
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="style.css">
@@ -17,6 +21,9 @@
   <meta name="theme-color" content="#063d49">
 </head>
 <body>
+  <h1 class="sr-only">Η Ιστορία του Pawsh – Από Chef σε Pet Groomer</h1>
+  <h2 class="sr-only">Η Αλεξάνδρα και το Όραμά της για το Pet Grooming</h2>
+  <p class="sr-only">Το Pawsh δημιουργήθηκε με αγάπη για τα ζώα από την Αλεξάνδρα, πρώην chef και νυν επαγγελματία groomer με σπουδές και εμπειρία στον χώρο.</p>
   <header class="bg-[#063d49] text-white">
     <!-- Desktop header -->
     <div class="hidden md:block">


### PR DESCRIPTION
## Summary
- add Greek SEO metadata for About page
- include screen-reader-only headings and description

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5a6d85fe4832080111ca52f8f5df2