### PR TITLE
Add SEO metadata and hidden headings to gallery page

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -13,8 +13,16 @@
   <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png">
   <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png">
   <meta name="theme-color" content="#063d49">
+  <meta name="title" content="Gallery – Pet Grooming στο Pawsh">
+  <meta name="description" content="Δείτε φωτογραφίες από τις υπηρεσίες μας, τα χαρούμενα σκυλάκια και τον χώρο μας στο Pawsh.">
+  <meta name="keywords" content="gallery, φωτογραφίες, grooming πριν και μετά, Pawsh σκυλάκια, pet grooming gallery, καλλωπισμός σκύλων">
+  <meta name="author" content="Pawsh Pet Grooming">
+  <meta name="robots" content="index, follow">
 </head>
 <body class="gallery-paw-bg">
+  <h1 class="sr-only">Pawsh Gallery – Πριν και Μετά τον Καλλωπισμό</h1>
+  <h2 class="sr-only">Δείτε τον Χώρο μας και τα Χαρούμενα Σκυλάκια μας</h2>
+  <p class="sr-only">Μια ματιά στις υπηρεσίες και το αποτέλεσμα που προσφέρει το Pawsh, μέσα από φωτογραφίες γεμάτες χαρά και φροντίδα.</p>
   <header class="bg-[#063d49] text-white">
     <!-- Desktop header -->
     <div class="hidden md:block">


### PR DESCRIPTION
## Summary
- add SEO meta tags (title, description, keywords, author, robots) to gallery page
- insert screen-reader-only headings and description for accessibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5a75a3f08832084cbd4d6b5ff1b6f