### PR TITLE
Update site.webmanifest for PWA readiness

### DIFF
--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,19 +1,20 @@
 {
-  "name": "Pawsh",
+  "name": "Pawsh – Pet Grooming",
   "short_name": "Pawsh",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#063d49",
   "icons": [
     {
       "src": "/android-chrome-192x192.png",
-      "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/png",
+      "sizes": "192x192"
     },
     {
       "src": "/android-chrome-512x512.png",
-      "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/png",
+      "sizes": "512x512"
     }
-  ],
-  "theme_color": "#063d49",
-  "background_color": "#063d49",
-  "display": "standalone"
+  ]
 }


### PR DESCRIPTION
## Summary
- add `start_url` and extend metadata in `site.webmanifest`
- use proper background color and theme for PWA

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5a7acf3cc83209bc5d29dc3d85e0f