### PR TITLE
Add radial social icons to main pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -30,11 +30,11 @@
       <div class="flex items-center justify-center relative py-2 border-b border-[#d7c9a9]">
         <a href="index.html" class="mx-auto"><img src="logo/logo.png" alt="Pawsh logo" class="h-16"></a>
         <div class="absolute right-4 flex space-x-2">
-          <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
-            <img src="logo/facebook icon.png" alt="Facebook" class="w-8 h-8 rounded-full">
+          <a href="https://www.facebook.com/profile.php?id=61578078265850" class="radial-icon" aria-label="Facebook" target="_blank" rel="noopener">
+            <img src="./assets/icons/facebook.svg" alt="Facebook Icon">
           </a>
-          <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
-            <img src="logo/instagram icon.png" alt="Instagram" class="w-8 h-8 rounded-full">
+          <a href="https://www.instagram.com/pawsh_pet_salon/" class="radial-icon" aria-label="Instagram" target="_blank" rel="noopener">
+            <img src="./assets/icons/instagram.svg" alt="Instagram Icon">
           </a>
         </div>
       </div>
@@ -64,11 +64,11 @@
       <a href="https://pawshpetbeautysalon.setmore.com" class="btn" target="_blank" rel="noopener">Κλείσε Ραντεβού</a>
       <p>Τηλέφωνο: 2104404084</p>
       <div class="flex space-x-4">
-        <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
-          <img src="logo/facebook icon.png" alt="Facebook" class="w-8 h-8 rounded-full">
+        <a href="https://www.facebook.com/profile.php?id=61578078265850" class="radial-icon" aria-label="Facebook" target="_blank" rel="noopener">
+          <img src="./assets/icons/facebook.svg" alt="Facebook Icon">
         </a>
-        <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
-          <img src="logo/instagram icon.png" alt="Instagram" class="w-8 h-8 rounded-full">
+        <a href="https://www.instagram.com/pawsh_pet_salon/" class="radial-icon" aria-label="Instagram" target="_blank" rel="noopener">
+          <img src="./assets/icons/instagram.svg" alt="Instagram Icon">
         </a>
       </div>
     </div>
@@ -98,11 +98,11 @@
         <img src="logo/logo2.png" alt="Pawsh logo" class="logo">
       </a>
       <div class="footer-socials">
-        <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
-          <img src="logo/facebook icon.png" alt="Facebook">
+        <a href="https://www.facebook.com/profile.php?id=61578078265850" class="radial-icon" aria-label="Facebook" target="_blank" rel="noopener">
+          <img src="./assets/icons/facebook.svg" alt="Facebook Icon">
         </a>
-        <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
-          <img src="logo/instagram icon.png" alt="Instagram">
+        <a href="https://www.instagram.com/pawsh_pet_salon/" class="radial-icon" aria-label="Instagram" target="_blank" rel="noopener">
+          <img src="./assets/icons/instagram.svg" alt="Instagram Icon">
         </a>
       </div>
       <div class="footer-links">

--- a/assets/icons/facebook.svg
+++ b/assets/icons/facebook.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M15 3h-2c-2.2 0-4 1.8-4 4v3H7v4h2v7h4v-7h3l1-4h-4V7a1 1 0 011-1h3V3z" fill="#fff"/>
+</svg>

--- a/assets/icons/instagram.svg
+++ b/assets/icons/instagram.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <rect x="3" y="3" width="18" height="18" rx="5" stroke="#fff" stroke-width="2"/>
+  <circle cx="12" cy="12" r="4" stroke="#fff" stroke-width="2"/>
+  <circle cx="17" cy="7" r="1.5" fill="#fff"/>
+</svg>

--- a/gallery.html
+++ b/gallery.html
@@ -29,11 +29,11 @@
       <div class="flex items-center justify-center relative py-2 border-b border-[#d7c9a9]">
         <a href="index.html" class="mx-auto"><img src="logo/logo.png" alt="Pawsh logo" class="h-16"></a>
         <div class="absolute right-4 flex space-x-2">
-          <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
-            <img src="logo/facebook icon.png" alt="Facebook" class="w-8 h-8 rounded-full">
+          <a href="https://www.facebook.com/profile.php?id=61578078265850" class="radial-icon" aria-label="Facebook" target="_blank" rel="noopener">
+            <img src="./assets/icons/facebook.svg" alt="Facebook Icon">
           </a>
-          <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
-            <img src="logo/instagram icon.png" alt="Instagram" class="w-8 h-8 rounded-full">
+          <a href="https://www.instagram.com/pawsh_pet_salon/" class="radial-icon" aria-label="Instagram" target="_blank" rel="noopener">
+            <img src="./assets/icons/instagram.svg" alt="Instagram Icon">
           </a>
         </div>
       </div>
@@ -63,11 +63,11 @@
       <a href="https://pawshpetbeautysalon.setmore.com" class="btn" target="_blank" rel="noopener">Κλείσε Ραντεβού</a>
       <p>Τηλέφωνο: 2104404084</p>
       <div class="flex space-x-4">
-        <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
-          <img src="logo/facebook icon.png" alt="Facebook" class="w-8 h-8 rounded-full">
+        <a href="https://www.facebook.com/profile.php?id=61578078265850" class="radial-icon" aria-label="Facebook" target="_blank" rel="noopener">
+          <img src="./assets/icons/facebook.svg" alt="Facebook Icon">
         </a>
-        <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
-          <img src="logo/instagram icon.png" alt="Instagram" class="w-8 h-8 rounded-full">
+        <a href="https://www.instagram.com/pawsh_pet_salon/" class="radial-icon" aria-label="Instagram" target="_blank" rel="noopener">
+          <img src="./assets/icons/instagram.svg" alt="Instagram Icon">
         </a>
       </div>
     </div>
@@ -118,11 +118,11 @@
         <img src="logo/logo2.png" alt="Pawsh logo" class="logo">
       </a>
       <div class="footer-socials">
-        <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
-          <img src="logo/facebook icon.png" alt="Facebook">
+        <a href="https://www.facebook.com/profile.php?id=61578078265850" class="radial-icon" aria-label="Facebook" target="_blank" rel="noopener">
+          <img src="./assets/icons/facebook.svg" alt="Facebook Icon">
         </a>
-        <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
-          <img src="logo/instagram icon.png" alt="Instagram">
+        <a href="https://www.instagram.com/pawsh_pet_salon/" class="radial-icon" aria-label="Instagram" target="_blank" rel="noopener">
+          <img src="./assets/icons/instagram.svg" alt="Instagram Icon">
         </a>
       </div>
       <div class="footer-links">

--- a/index.html
+++ b/index.html
@@ -34,11 +34,11 @@
         <div class="flex items-center justify-center relative py-2 border-b border-[#d7c9a9]">
           <a href="index.html" class="mx-auto"><img src="logo/logo.png" alt="Pawsh logo" class="h-16"></a>
           <div class="absolute right-4 flex space-x-2">
-            <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
-              <img src="logo/facebook icon.png" alt="Facebook" class="w-8 h-8 rounded-full">
+            <a href="https://www.facebook.com/profile.php?id=61578078265850" class="radial-icon" aria-label="Facebook" target="_blank" rel="noopener">
+              <img src="./assets/icons/facebook.svg" alt="Facebook Icon">
             </a>
-            <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
-              <img src="logo/instagram icon.png" alt="Instagram" class="w-8 h-8 rounded-full">
+            <a href="https://www.instagram.com/pawsh_pet_salon/" class="radial-icon" aria-label="Instagram" target="_blank" rel="noopener">
+              <img src="./assets/icons/instagram.svg" alt="Instagram Icon">
             </a>
           </div>
         </div>
@@ -68,11 +68,11 @@
         <a href="https://pawshpetbeautysalon.setmore.com" class="btn" target="_blank" rel="noopener">Κλείσε Ραντεβού</a>
         <p>Τηλέφωνο: 2104404084</p>
         <div class="flex space-x-4">
-          <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
-            <img src="logo/facebook icon.png" alt="Facebook" class="w-8 h-8 rounded-full">
+          <a href="https://www.facebook.com/profile.php?id=61578078265850" class="radial-icon" aria-label="Facebook" target="_blank" rel="noopener">
+            <img src="./assets/icons/facebook.svg" alt="Facebook Icon">
           </a>
-          <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
-            <img src="logo/instagram icon.png" alt="Instagram" class="w-8 h-8 rounded-full">
+          <a href="https://www.instagram.com/pawsh_pet_salon/" class="radial-icon" aria-label="Instagram" target="_blank" rel="noopener">
+            <img src="./assets/icons/instagram.svg" alt="Instagram Icon">
           </a>
         </div>
       </div>
@@ -400,11 +400,11 @@
         <img src="logo/logo2.png" alt="Pawsh logo" class="logo">
       </a>
       <div class="footer-socials">
-        <a href="https://www.facebook.com/profile.php?id=61578078265850" target="_blank">
-          <img src="logo/facebook icon.png">
+        <a href="https://www.facebook.com/profile.php?id=61578078265850" class="radial-icon" aria-label="Facebook" target="_blank" rel="noopener">
+          <img src="./assets/icons/facebook.svg" alt="Facebook Icon">
         </a>
-        <a href="https://www.instagram.com/pawsh_pet_salon/" target="_blank">
-          <img src="logo/instagram icon.png">
+        <a href="https://www.instagram.com/pawsh_pet_salon/" class="radial-icon" aria-label="Instagram" target="_blank" rel="noopener">
+          <img src="./assets/icons/instagram.svg" alt="Instagram Icon">
         </a>
       </div>
       <div class="footer-links">

--- a/style.css
+++ b/style.css
@@ -16,6 +16,21 @@ a {
   color: var(--accent);
   text-decoration: none;
 }
+
+.radial-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.radial-icon img {
+  width: 20px;
+  height: 20px;
+}
 header {
   background: var(--accent);
   color: white;


### PR DESCRIPTION
## Summary
- add reusable radial icon style and SVG assets
- display Facebook/Instagram radial icons on index, about, and gallery pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5b13bc95c832089a3a999757c9b3f