### PR TITLE
Use existing logo asset for gallery

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -73,7 +73,9 @@
     </div>
   </div>
 
-  <main class="py-8"></main>
+  <main class="py-8">
+    <img src="logo/logo2.png" alt="Pawsh alternate logo" class="mx-auto" loading="lazy" width="4688" height="4688">
+  </main>
   <footer id="contact">
     <div class="footer-column">
       <h4>Στοιχεία Επικοινωνίας</h4>


### PR DESCRIPTION
## Summary
- display existing `logo2.png` on the gallery page with lazy loading and explicit dimensions
- remove redundant `logo4.png` binary asset to keep the repository slim

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5cb7c6cbc8320a4fc196b2e191605