### PR TITLE
Fix gallery dog assets to use existing JPEGs

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,6 +281,10 @@
         <div class="swiper-slide dog-slide"><img src="dogs/dog18.jpg" alt="Σκύλος 18" loading="lazy" width="600" height="600"></div>
         <div class="swiper-slide dog-slide"><img src="dogs/dog19.png" alt="Σκύλος 19" loading="lazy" width="600" height="600"></div>
         <div class="swiper-slide dog-slide"><img src="dogs/dog20.png" alt="Σκύλος 20" loading="lazy" width="600" height="600"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog21.jpg" alt="Σκύλος 21" loading="lazy" width="600" height="600"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog22.jpg" alt="Σκύλος 22" loading="lazy" width="600" height="600"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog23.jpg" alt="Σκύλος 23" loading="lazy" width="600" height="600"></div>
+        <div class="swiper-slide dog-slide"><img src="dogs/dog24.jpg" alt="Σκύλος 24" loading="lazy" width="600" height="600"></div>
       </div>
 
       <!-- Πλοήγηση -->
@@ -311,6 +315,10 @@
         <div class="swiper-slide"><img src="dogs/dog18.jpg" alt="" width="80" height="80"></div>
         <div class="swiper-slide"><img src="dogs/dog19.png" alt="" width="80" height="80"></div>
         <div class="swiper-slide"><img src="dogs/dog20.png" alt="" width="80" height="80"></div>
+        <div class="swiper-slide"><img src="dogs/dog21.jpg" alt="" width="80" height="80"></div>
+        <div class="swiper-slide"><img src="dogs/dog22.jpg" alt="" width="80" height="80"></div>
+        <div class="swiper-slide"><img src="dogs/dog23.jpg" alt="" width="80" height="80"></div>
+        <div class="swiper-slide"><img src="dogs/dog24.jpg" alt="" width="80" height="80"></div>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- replace the gallery slider and thumbnails to point at the existing JPEG sources for dogs 21–24
- remove the four incorrect PNG placeholders that were added previously

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d58baad094832099835b0287c488b9