### PR TITLE
Adjust mobile gallery dimensions

### DIFF
--- a/style.css
+++ b/style.css
@@ -802,13 +802,20 @@ body.pawsh-gallery-no-scroll {
   }
 
   .pawsh-gallery-scroller {
-    height: 200px;
+    height: 800px;
     padding-inline: 1rem;
     --pawsh-gallery-gap: 1rem;
   }
 
   .pawsh-gallery-track {
-    grid-auto-columns: 100%;
+    grid-auto-columns: 800px;
+  }
+
+  .pawsh-gallery-slide,
+  .pawsh-gallery-slide-button,
+  .pawsh-gallery-slide img {
+    width: 800px;
+    height: 800px;
   }
 
   .pawsh-gallery-lightbox {


### PR DESCRIPTION
## Summary
- increase the mobile gallery scroller height to 800px so the gallery opens at full size
- ensure each gallery slide, button, and image renders at 800x800px on small screens

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d848a1d1508320a001f6c731c516f0