### PR TITLE
Adjust gallery height on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -802,13 +802,19 @@ body.pawsh-gallery-no-scroll {
   }
 
   .pawsh-gallery-scroller {
-    height: 200px;
+    height: calc(100vw - 2rem);
     padding-inline: 1rem;
     --pawsh-gallery-gap: 1rem;
   }
 
   .pawsh-gallery-track {
     grid-auto-columns: 100%;
+    align-items: stretch;
+  }
+
+  .pawsh-gallery-slide {
+    height: auto;
+    aspect-ratio: 1 / 1;
   }
 
   .pawsh-gallery-lightbox {


### PR DESCRIPTION
## Summary
- increase the mobile gallery scroller height to match its available width
- ensure mobile gallery slides stretch and maintain a square aspect ratio for images

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d84ceb15b88320ba050535905bdaa2