### PR TITLE
Increase desktop gallery image height

### DIFF
--- a/style.css
+++ b/style.css
@@ -900,6 +900,12 @@ body.pawsh-gallery-no-scroll {
   overflow: hidden;
 }
 
+@media (min-width: 1024px) {
+  .pawsh-gallery-scroller {
+    height: 320px;
+  }
+}
+
 @media (max-width: 920px) {
   .pawsh-gallery-scroller {
     height: 220px;


### PR DESCRIPTION
## Summary
- increase the home page gallery scroller height on desktop to make the images appear larger

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8506d66f883208dc8b99d3feadc14