### PR TITLE
Adjust gallery layout for before/after comparison

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -79,8 +79,7 @@
   </div>
 
   <main class="py-8">
-    <img src="logo/logo2.png" alt="Pawsh alternate logo" class="mx-auto" loading="lazy" width="4688" height="4688">
-
+    <h2 class="text-center text-3xl md:text-4xl font-semibold tracking-wide text-[#063d49] mb-8">Πριν / Μετά</h2>
     <section class="pawsh-compare-grid" aria-label="Σύγκριση φωτογραφιών πριν και μετά">
       <div class="pawsh-compare">
         <img class="pc-after" src="images/after1.jpg" alt="Μετά" loading="lazy">

--- a/style.css
+++ b/style.css
@@ -404,11 +404,12 @@ footer img.logo {
   padding: 0 1rem 3rem;
   display: grid;
   gap: 2rem;
+  grid-template-columns: 1fr;
 }
 
 @media (min-width: 768px) {
   .pawsh-compare-grid {
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the top logo image from the gallery and replace it with a clear "Πριν / Μετά" title
- update the compare slider grid styling so the before/after pairs render in two rows with two items per row on larger screens

## Testing
- `npm start` (verified gallery page renders with updated layout)


------
https://chatgpt.com/codex/tasks/task_e_68d8517770c48320bf36b84dddde4378