### PR TITLE
Add Pawsh Models heading above gallery

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,6 +311,7 @@
       <a href="https://pawshpetbeautysalon.setmore.com" class="hero-cta" target="_blank" rel="noopener">Κλείσε Ραντεβού</a>
     </section>
 
+<h2 class="pawsh-gallery-heading">Pawsh Models</h2>
 <section id="gallery" class="pawsh-gallery-section" aria-label="Gallery σκύλων">
   <div class="pawsh-gallery-container">
     <div class="pawsh-gallery-scroller" tabindex="0" aria-label="Συλλογή φωτογραφιών Pawsh" role="list">

--- a/style.css
+++ b/style.css
@@ -713,6 +713,15 @@ footer img.logo {
 
 
 /* Pawsh gallery */
+.pawsh-gallery-heading {
+  text-align: center;
+  font-size: clamp(2rem, 5vw, 2.75rem);
+  color: #063d49;
+  font-weight: 700;
+  margin: 4rem auto 1.5rem;
+  padding: 0 1rem;
+}
+
 .pawsh-gallery-section {
   padding: 3rem 0;
 }


### PR DESCRIPTION
## Summary
- add a "Pawsh Models" heading above the gallery section on the homepage
- style the new heading to match the site's typography and spacing

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d853683e0c8320acffe4ed46116cea