### PR TITLE
Align gallery slider with provided before/after filenames

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -82,9 +82,9 @@
     <h2 class="text-center text-3xl md:text-4xl font-semibold tracking-wide text-[#063d49] mb-8">Πριν / Μετά</h2>
     <section class="pawsh-compare-grid" aria-label="Σύγκριση φωτογραφιών πριν και μετά">
       <div class="pawsh-compare">
-        <img class="pc-after" src="images/after1.jpg" alt="Μετά" loading="lazy">
-        <img class="pc-before" src="images/before1.jpg" alt="Πριν" loading="lazy">
-        <input type="range" class="pc-slider" min="0" max="100" value="50" aria-label="Σύγκριση πριν και μετά 1">
+        <img class="pc-after" src="before&amp;after/1*.jpg" alt="Σκυλάκι μετά τον καλλωπισμό" loading="lazy">
+        <img class="pc-before" src="before&amp;after/1.jpg" alt="Σκυλάκι πριν τον καλλωπισμό" loading="lazy">
+        <input type="range" class="pc-slider" min="0" max="100" value="50" aria-label="Σύγκριση πριν και μετά – Καλλωπισμός 1">
         <div class="pc-handle"><span></span></div>
       </div>
       <div class="pawsh-compare">


### PR DESCRIPTION
## Summary
- point the first gallery slider at the provided before and after filenames
- rename the imported assets so their filenames stay in sync with the HTML usage

## Testing
- not run (static content change)

------
https://chatgpt.com/codex/tasks/task_e_68daac69b1ac8320b2d424819d5528c2