### PR TITLE
Adjust compare slider clip-path transition speed

### DIFF
--- a/style.css
+++ b/style.css
@@ -442,7 +442,7 @@ footer img.logo {
 .pawsh-compare .pc-before {
   z-index: 2;
   clip-path: inset(0 calc(100% - var(--pc-position) * 1%) 0 0);
-  transition: clip-path 0.25s ease;
+  transition: clip-path 80ms linear;
 }
 
 .pawsh-compare .pc-slider {


### PR DESCRIPTION
## Summary
- shorten the clip-path transition for the compare slider so updates feel more immediate

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dab9b296bc83208aadbe3de06d7607