### PR TITLE
Add dogs28 and dogs29 images to gallery

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -44,11 +44,16 @@ document.addEventListener('DOMContentLoaded', () => {
     [22, 'Σκύλος 22'],
     [23, 'Σκύλος 23'],
     [24, 'Σκύλος 24'],
+    [25, 'Σκύλος 25'],
+    [26, 'Σκύλος 26'],
+    [27, 'Σκύλος 27'],
+    [28, 'Σκύλος 28'],
+    [29, 'Σκύλος 29'],
   ]);
 
   const slidesData = [];
   const slides = [];
-  const totalImages = 27;
+  const totalImages = 29;
 
   for (let i = 1; i <= totalImages; i += 1) {
     const imageSrc = `./dogs/dog${i}.jpg`;


### PR DESCRIPTION
## Summary
- extend the gallery alt text map to cover images 25 through 29
- increase the total gallery image count so dogs28 and dogs29 are included in the scroller

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1286e578c8320a8db836806b63879