### PR TITLE
Align gallery filename construction with dog prefix

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -44,14 +44,21 @@ document.addEventListener('DOMContentLoaded', () => {
     [22, 'Σκύλος 22'],
     [23, 'Σκύλος 23'],
     [24, 'Σκύλος 24'],
+    [25, 'Σκύλος 25'],
+    [26, 'Σκύλος 26'],
+    [27, 'Σκύλος 27'],
+    [28, 'Σκύλος 28'],
+    [29, 'Σκύλος 29'],
   ]);
 
   const slidesData = [];
   const slides = [];
-  const totalImages = 27;
+  const totalImages = 29;
+  const imageFilePrefix = 'dog';
 
   for (let i = 1; i <= totalImages; i += 1) {
-    const imageSrc = `./dogs/dog${i}.jpg`;
+    const imageFileName = `${imageFilePrefix}${i}.jpg`;
+    const imageSrc = `./dogs/${imageFileName}`;
     const imageAlt = altTextMap.get(i) || `Pawsh gallery photo ${i}`;
 
     const slide = document.createElement('div');


### PR DESCRIPTION
## Summary
- ensure gallery slides generate file names with the `dog` prefix to match dog28.jpg and dog29.jpg assets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1286e578c8320a8db836806b63879