### PR TITLE
Fix gallery image loading on index page

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -54,6 +54,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const slidesData = [];
   const slides = [];
   const totalImages = 29;
+  const imageFilePrefix = 'dog';
 
 
   for (let i = 1; i <= totalImages; i += 1) {


### PR DESCRIPTION
## Summary
- define the gallery image filename prefix so the JavaScript can build image paths without errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4257a058483209420dfa748090013