### PR TITLE
Add subtle 100+ Google reviews messaging, thank-you section and non-intrusive trust popup

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -166,7 +166,7 @@
       <img src="../assets/hero/salon4.webp" alt="Cute puppy in the arms of a groomer at Pawsh" class="slide slide--salon4">
     </div>
     <div class="hero-content">
-      <a href="https://www.google.com/maps/search/?api=1&query=Pawsh%20Pet%20Beauty%20Salon%2C%20Agias%20Glykerias%2062%2C%20Galatsi" class="google-review-badge" target="_blank" rel="noopener" aria-label="See Pawsh reviews on Google">⭐ 5.0 from 80+ Google reviews</a>
+      <a href="https://www.google.com/maps/search/?api=1&query=Pawsh%20Pet%20Beauty%20Salon%2C%20Agias%20Glykerias%2062%2C%20Galatsi" class="google-review-badge" target="_blank" rel="noopener" aria-label="See Pawsh reviews on Google">⭐ 5.0 from 100+ Google reviews</a>
       <h1>Welcome to Pawsh</h1>
       <h2>For posh paws!</h2>
       <div class="hero-actions">
@@ -574,15 +574,33 @@
     <div class="reviews-actions">
       <a href="https://www.google.com/maps/search/?api=1&query=Pawsh%20Pet%20Beauty%20Salon%2C%20Agias%20Glykerias%2062%2C%20Galatsi" class="hero-cta hero-cta-secondary" target="_blank" rel="noopener">See all Google reviews</a>
       <a href="https://pawshpetbeautysalon.setmore.com" class="hero-cta" target="_blank" rel="noopener">Book Appointment</a>
-      <p class="cta-trust-note">⭐ 5.0 on Google from 80+ clients</p>
+      <p class="cta-trust-note">⭐ 5.0 from 100+ Google reviews</p>
     </div>
   </section>
 
-  
+<section class="reviews-thankyou" aria-label="100+ Google reviews">
+  <div class="reviews-thankyou__inner">
+    <h3>100+ Google reviews</h3>
+    <p>Thank you for your trust! Pawsh Pet Beauty Salon has reached 100+ Google reviews with a 5.0 rating. Your support inspires us to keep offering calm, careful and professional grooming for every pet.</p>
+    <a href="https://www.google.com/maps/search/?api=1&query=Pawsh%20Pet%20Beauty%20Salon%2C%20Agias%20Glykerias%2062%2C%20Galatsi" class="hero-cta hero-cta-secondary" target="_blank" rel="noopener">See all Google reviews</a>
+  </div>
+</section>
+
     <section class="map">
       <a class="map-link" href="https://www.google.com/maps/search/?api=1&query=%CE%91%CE%B3%CE%AF%CE%B1%CF%82+%CE%93%CE%BB%CF%85%CE%BA%CE%B5%CF%81%CE%AF%CE%B1%CF%82+62%2C+%CE%93%CE%B1%CE%BB%CE%AC%CF%84%CF%83%CE%B9+111+47%2C+%CE%95%CE%BB%CE%BB%CE%AC%CE%B4%CE%B1" target="_blank" rel="noopener">Open the address in Google Maps</a>
       <iframe src="https://www.google.com/maps?q=62+Agias+Glykerias,+Galatsi,+111+47,+Greece&output=embed" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
     </section>
+
+
+  <div id="trust-popup" class="trust-popup" role="dialog" aria-labelledby="trust-popup-title" aria-describedby="trust-popup-text" aria-live="polite" aria-hidden="true">
+    <button type="button" class="trust-popup__close" id="trust-popup-close" aria-label="Close">×</button>
+    <h3 id="trust-popup-title">Thank you! 🐾</h3>
+    <p id="trust-popup-text">We have reached 100+ Google reviews with a 5.0 rating. Your trust means everything to us.</p>
+    <div class="trust-popup__actions">
+      <a href="https://www.google.com/maps/search/?api=1&query=Pawsh%20Pet%20Beauty%20Salon%2C%20Agias%20Glykerias%2062%2C%20Galatsi" class="hero-cta hero-cta-secondary" target="_blank" rel="noopener">See reviews</a>
+      <a href="https://pawshpetbeautysalon.setmore.com" class="hero-cta" target="_blank" rel="noopener">Book appointment</a>
+    </div>
+  </div>
 
   <div id="cookie-banner" class="cookie-banner" role="dialog" aria-live="polite" aria-modal="true" aria-hidden="true">
     <h2 class="cookie-banner__heading">A quick note about cookies</h2>
@@ -697,6 +715,74 @@
       backToTop.addEventListener('click', () => {
         window.scrollTo({ top: 0, behavior: 'smooth' });
       });
+    }
+
+
+    const trustPopup = document.getElementById('trust-popup');
+    const trustPopupClose = document.getElementById('trust-popup-close');
+    if (trustPopup && trustPopupClose) {
+      const popupStorageKey = 'pawsh_trust_popup_seen';
+      const popupDelayMs = 5000;
+      const popupScrollThreshold = 0.35;
+      let popupShown = false;
+
+      const popupStorageAvailable = (() => {
+        try {
+          const testKey = '__pawsh_trust_popup_test__';
+          localStorage.setItem(testKey, '1');
+          localStorage.removeItem(testKey);
+          return true;
+        } catch (error) {
+          return false;
+        }
+      })();
+
+      const popupAlreadySeen = popupStorageAvailable && localStorage.getItem(popupStorageKey) === 'true';
+
+      const hidePopup = () => {
+        trustPopup.classList.remove('is-visible');
+        trustPopup.setAttribute('aria-hidden', 'true');
+        if (popupStorageAvailable) {
+          localStorage.setItem(popupStorageKey, 'true');
+        }
+      };
+
+      const showPopup = () => {
+        if (popupShown || popupAlreadySeen) {
+          return;
+        }
+        popupShown = true;
+        trustPopup.classList.add('is-visible');
+        trustPopup.setAttribute('aria-hidden', 'false');
+        window.removeEventListener('scroll', onPopupScroll);
+      };
+
+      const onPopupScroll = () => {
+        const scrollableHeight = document.documentElement.scrollHeight - window.innerHeight;
+        if (scrollableHeight <= 0) {
+          return;
+        }
+        const scrollRatio = window.scrollY / scrollableHeight;
+        if (scrollRatio >= popupScrollThreshold) {
+          showPopup();
+        }
+      };
+
+      if (!popupAlreadySeen) {
+        const popupTimer = window.setTimeout(showPopup, popupDelayMs);
+        window.addEventListener('scroll', onPopupScroll, { passive: true });
+        trustPopupClose.addEventListener('click', () => {
+          window.clearTimeout(popupTimer);
+          hidePopup();
+        });
+
+        trustPopup.querySelectorAll('a').forEach((link) => {
+          link.addEventListener('click', () => {
+            window.clearTimeout(popupTimer);
+            hidePopup();
+          });
+        });
+      }
     }
 
     const cookieBanner = document.getElementById('cookie-banner');

--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
       <img src="assets/hero/salon4.webp" alt="Χαριτωμένο κουτάβι στην αγκαλιά groomer στο Pawsh" class="slide slide--salon4">
     </div>
     <div class="hero-content">
-      <a href="https://www.google.com/maps/search/?api=1&query=Pawsh%20Pet%20Beauty%20Salon%2C%20Agias%20Glykerias%2062%2C%20Galatsi" class="google-review-badge" target="_blank" rel="noopener" aria-label="Δες τις αξιολογήσεις του Pawsh στο Google">⭐ 5.0 από 93+ αξιολογήσεις στο Google</a>
+      <a href="https://www.google.com/maps/search/?api=1&query=Pawsh%20Pet%20Beauty%20Salon%2C%20Agias%20Glykerias%2062%2C%20Galatsi" class="google-review-badge" target="_blank" rel="noopener" aria-label="Δες τις αξιολογήσεις του Pawsh στο Google">⭐ 5.0 από 100+ αξιολογήσεις στο Google</a>
       <h1>Καλώς ήρθες στο Pawsh</h1>
       <h2>Για κομψές πατούσες!</h2>
       <div class="hero-actions">
@@ -593,15 +593,33 @@
     <div class="reviews-actions">
       <a href="https://www.google.com/maps/search/?api=1&query=Pawsh%20Pet%20Beauty%20Salon%2C%20Agias%20Glykerias%2062%2C%20Galatsi" class="hero-cta hero-cta-secondary" target="_blank" rel="noopener">Δες όλες τις αξιολογήσεις στο Google</a>
       <a href="https://pawshpetbeautysalon.setmore.com" class="hero-cta" target="_blank" rel="noopener">Κλείσε Ραντεβού</a>
-      <p class="cta-trust-note">⭐ 5.0 στο Google από 93+ πελάτες</p>
+      <p class="cta-trust-note">⭐ 5.0 από 100+ αξιολογήσεις στο Google</p>
     </div>
   </section>
 
-  
+<section class="reviews-thankyou" aria-label="100+ αξιολογήσεις στο Google">
+  <div class="reviews-thankyou__inner">
+    <h3>100+ αξιολογήσεις στο Google</h3>
+    <p>Σας ευχαριστούμε για την εμπιστοσύνη! Το Pawsh Pet Beauty Salon ξεπέρασε τις 100 αξιολογήσεις στο Google με βαθμολογία 5.0. Η αγάπη και η στήριξή σας μάς δίνουν δύναμη να προσφέρουμε καθημερινά προσεγμένη, ήρεμη και επαγγελματική φροντίδα σε κάθε κατοικίδιο.</p>
+    <a href="https://www.google.com/maps/search/?api=1&query=Pawsh%20Pet%20Beauty%20Salon%2C%20Agias%20Glykerias%2062%2C%20Galatsi" class="hero-cta hero-cta-secondary" target="_blank" rel="noopener">Δες όλες τις αξιολογήσεις στο Google</a>
+  </div>
+</section>
+
     <section class="map">
       <a class="map-link" href="https://www.google.com/maps/search/?api=1&query=%CE%91%CE%B3%CE%AF%CE%B1%CF%82+%CE%93%CE%BB%CF%85%CE%BA%CE%B5%CF%81%CE%AF%CE%B1%CF%82+62%2C+%CE%93%CE%B1%CE%BB%CE%AC%CF%84%CF%83%CE%B9+111+47%2C+%CE%95%CE%BB%CE%BB%CE%AC%CE%B4%CE%B1" target="_blank" rel="noopener">Άνοιξε τη διεύθυνση στο Google Maps</a>
       <iframe src="https://www.google.com/maps?q=Αγίας+Γλυκερίας+62,+Γαλάτσι,+111+47,+Ελλάδα&output=embed" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
     </section>
+
+
+  <div id="trust-popup" class="trust-popup" role="dialog" aria-labelledby="trust-popup-title" aria-describedby="trust-popup-text" aria-live="polite" aria-hidden="true">
+    <button type="button" class="trust-popup__close" id="trust-popup-close" aria-label="Κλείσιμο">×</button>
+    <h3 id="trust-popup-title">Σας ευχαριστούμε! 🐾</h3>
+    <p id="trust-popup-text">Ξεπεράσαμε τις 100 αξιολογήσεις στο Google με βαθμολογία 5.0. Η εμπιστοσύνη σας είναι η μεγαλύτερη επιβράβευση για εμάς.</p>
+    <div class="trust-popup__actions">
+      <a href="https://www.google.com/maps/search/?api=1&query=Pawsh%20Pet%20Beauty%20Salon%2C%20Agias%20Glykerias%2062%2C%20Galatsi" class="hero-cta hero-cta-secondary" target="_blank" rel="noopener">Δες αξιολογήσεις</a>
+      <a href="https://pawshpetbeautysalon.setmore.com" class="hero-cta" target="_blank" rel="noopener">Κλείσε ραντεβού</a>
+    </div>
+  </div>
 
   <div id="cookie-banner" class="cookie-banner" role="dialog" aria-live="polite" aria-modal="true" aria-hidden="true">
     <h2 class="cookie-banner__heading">Μια μικρή ενημέρωση για τα cookies</h2>
@@ -715,6 +733,74 @@
       backToTop.addEventListener('click', () => {
         window.scrollTo({ top: 0, behavior: 'smooth' });
       });
+    }
+
+
+    const trustPopup = document.getElementById('trust-popup');
+    const trustPopupClose = document.getElementById('trust-popup-close');
+    if (trustPopup && trustPopupClose) {
+      const popupStorageKey = 'pawsh_trust_popup_seen';
+      const popupDelayMs = 5000;
+      const popupScrollThreshold = 0.35;
+      let popupShown = false;
+
+      const popupStorageAvailable = (() => {
+        try {
+          const testKey = '__pawsh_trust_popup_test__';
+          localStorage.setItem(testKey, '1');
+          localStorage.removeItem(testKey);
+          return true;
+        } catch (error) {
+          return false;
+        }
+      })();
+
+      const popupAlreadySeen = popupStorageAvailable && localStorage.getItem(popupStorageKey) === 'true';
+
+      const hidePopup = () => {
+        trustPopup.classList.remove('is-visible');
+        trustPopup.setAttribute('aria-hidden', 'true');
+        if (popupStorageAvailable) {
+          localStorage.setItem(popupStorageKey, 'true');
+        }
+      };
+
+      const showPopup = () => {
+        if (popupShown || popupAlreadySeen) {
+          return;
+        }
+        popupShown = true;
+        trustPopup.classList.add('is-visible');
+        trustPopup.setAttribute('aria-hidden', 'false');
+        window.removeEventListener('scroll', onPopupScroll);
+      };
+
+      const onPopupScroll = () => {
+        const scrollableHeight = document.documentElement.scrollHeight - window.innerHeight;
+        if (scrollableHeight <= 0) {
+          return;
+        }
+        const scrollRatio = window.scrollY / scrollableHeight;
+        if (scrollRatio >= popupScrollThreshold) {
+          showPopup();
+        }
+      };
+
+      if (!popupAlreadySeen) {
+        const popupTimer = window.setTimeout(showPopup, popupDelayMs);
+        window.addEventListener('scroll', onPopupScroll, { passive: true });
+        trustPopupClose.addEventListener('click', () => {
+          window.clearTimeout(popupTimer);
+          hidePopup();
+        });
+
+        trustPopup.querySelectorAll('a').forEach((link) => {
+          link.addEventListener('click', () => {
+            window.clearTimeout(popupTimer);
+            hidePopup();
+          });
+        });
+      }
     }
 
     const cookieBanner = document.getElementById('cookie-banner');

--- a/style.css
+++ b/style.css
@@ -383,10 +383,10 @@ h1, h2 {
   gap: 0.4rem;
   padding: 0.55rem 1rem;
   border-radius: 999px;
-  background: rgba(215, 201, 169, 0.18);
+  background: rgba(215, 201, 169, 0.3);
   border: 1px solid rgba(215, 201, 169, 0.75);
-  color: #f6ead0;
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.16);
+  color: #fff5df;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.22);
   backdrop-filter: blur(8px);
   font-weight: 600;
   letter-spacing: 0.01em;
@@ -395,8 +395,8 @@ h1, h2 {
 
 .google-review-badge:hover {
   transform: translateY(-1px);
-  background: rgba(215, 201, 169, 0.28);
-  border-color: #f6ead0;
+  background: rgba(215, 201, 169, 0.38);
+  border-color: #fff5df;
 }
 
 .hero-description {
@@ -1757,4 +1757,112 @@ footer a {
   margin-top: 0.75rem;
   font-size: 0.95rem;
   color: var(--secondary);
+}
+
+
+.reviews-thankyou {
+  max-width: 1100px;
+  margin: 1.5rem auto 2rem;
+  padding: 0 1rem;
+}
+
+.reviews-thankyou__inner {
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.98), rgba(246, 234, 208, 0.94));
+  border: 1px solid rgba(6, 61, 73, 0.12);
+  border-radius: 18px;
+  box-shadow: 0 12px 28px rgba(6, 61, 73, 0.08);
+  padding: clamp(1.1rem, 2.5vw, 1.75rem);
+  text-align: center;
+}
+
+.reviews-thankyou__inner h3 {
+  margin: 0 0 0.65rem;
+  color: var(--accent);
+  font-size: clamp(1.35rem, 3vw, 1.8rem);
+}
+
+.reviews-thankyou__inner p {
+  margin: 0 auto 1rem;
+  max-width: 760px;
+  color: var(--secondary);
+  line-height: 1.65;
+}
+
+.trust-popup {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 70;
+  width: min(360px, calc(100% - 2rem));
+  background: rgba(255, 255, 255, 0.96);
+  border: 1px solid rgba(6, 61, 73, 0.16);
+  border-radius: 14px;
+  box-shadow: 0 16px 38px rgba(6, 61, 73, 0.22);
+  padding: 1rem;
+  opacity: 0;
+  transform: translateY(10px);
+  pointer-events: none;
+  transition: opacity 0.28s ease, transform 0.28s ease;
+}
+
+.trust-popup.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.trust-popup h3 {
+  margin: 0 1.8rem 0.4rem 0;
+  color: var(--accent);
+  font-size: 1.12rem;
+}
+
+.trust-popup p {
+  margin: 0 0 0.85rem;
+  color: var(--secondary);
+  line-height: 1.5;
+  font-size: 0.95rem;
+}
+
+.trust-popup__close {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.45rem;
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  font-size: 1.35rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.trust-popup__actions {
+  display: flex;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+}
+
+.trust-popup__actions .hero-cta {
+  margin-top: 0;
+  min-width: auto;
+  padding: 0.55rem 0.9rem;
+  font-size: 0.92rem;
+}
+
+@media (max-width: 640px) {
+  .trust-popup {
+    right: 0.75rem;
+    left: 0.75rem;
+    width: auto;
+    bottom: 0.75rem;
+  }
+
+  .trust-popup__actions {
+    flex-direction: column;
+  }
+
+  .trust-popup__actions .hero-cta {
+    width: 100%;
+    justify-content: center;
+  }
 }


### PR DESCRIPTION
### Motivation
- Refresh visible Google review counts on both Greek and English homepages to reflect the new 100+ milestone while preserving the current design and tone. 
- Provide a lightweight, on-site thank-you and a subtle trust prompt to increase social proof without changing SEO, hero layout, navigation or existing testimonials. 
- Improve floating review badge legibility (contrast and opacity) while keeping it elegant and non-intrusive. 

### Description
- Updated visible review copy in `index.html` and `en/index.html` to the exact requested strings: `⭐ 5.0 από 100+ αξιολογήσεις στο Google` (GR) and `⭐ 5.0 from 100+ Google reviews` (EN). 
- Added a subtle thank-you block near the reviews section in both `index.html` and `en/index.html` using existing button classes (`hero-cta` / `hero-cta-secondary`) and the exact Greek / English text and CTA labels requested. 
- Added a lightweight, homepage-only trust popup HTML to both homepages and inserted JavaScript that shows the popup after `5000ms` OR after `35%` scroll (whichever comes first), includes a close button, two CTA actions, and sets `localStorage` key `pawsh_trust_popup_seen` so the popup only appears once per visitor. 
- Improved floating review badge styling in `style.css` by increasing background opacity, improving text contrast and shadow, and added CSS for the new thank-you block and the responsive, non-intrusive popup. 
- Files modified: `index.html`, `en/index.html`, `style.css`.

### Testing
- Ran `npm test` (project `test` script) and it completed successfully. 
- Verified presence of updated strings, new `reviews-thankyou` section and `trust-popup` markup by searching the codebase with `rg`; checks returned the new `100+` strings and the `pawsh_trust_popup_seen` key. 
- Confirmed popup logic is present and uses `localStorage` to persist the seen state and that popup trigger uses the `5000ms` timer and `0.35` scroll threshold in the injected script.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef94d832448320b7da016ccb3ff874)