### PR TITLE
Add 100 Google reviews celebration image to homepage trust section

### DIFF
--- a/index.html
+++ b/index.html
@@ -321,6 +321,14 @@
     #reviews .hero-cta:hover {
       border: 2px solid #063d49;
     }
+
+    .reviews-celebration-image {
+      display: block;
+      max-width: 240px;
+      width: 100%;
+      margin: 20px auto 0;
+      border-radius: 12px;
+    }
     @media (min-width: 1024px) {
       .hero .slides {
         display: grid;
@@ -602,6 +610,12 @@
     <h3>100+ αξιολογήσεις στο Google</h3>
     <p>Σας ευχαριστούμε για την εμπιστοσύνη! Το Pawsh Pet Beauty Salon ξεπέρασε τις 100 αξιολογήσεις στο Google με βαθμολογία 5.0. Η αγάπη και η στήριξή σας μάς δίνουν δύναμη να προσφέρουμε καθημερινά προσεγμένη, ήρεμη και επαγγελματική φροντίδα σε κάθε κατοικίδιο.</p>
     <a href="https://www.google.com/maps/search/?api=1&query=Pawsh%20Pet%20Beauty%20Salon%2C%20Agias%20Glykerias%2062%2C%20Galatsi" class="hero-cta hero-cta-secondary" target="_blank" rel="noopener">Δες όλες τις αξιολογήσεις στο Google</a>
+    <img 
+      src="./assets/reviews/pawsh-100-axiologiseis-google-galatsi.webp"
+      alt="Pawsh 100 αξιολογήσεις Google στο Γαλάτσι - καλλωπισμός σκύλων Αθήνα"
+      class="reviews-celebration-image"
+      loading="lazy"
+    >
   </div>
 </section>
 


### PR DESCRIPTION
### Motivation
- Add a visual trust element celebrating 100+ Google reviews near the existing reviews/thank-you area without changing layout, popup logic, or SEO metadata.

### Description
- Inserted the exact image markup into `index.html` inside `<section class="reviews-thankyou">` immediately after the existing Google reviews CTA link and before the closing `.reviews-thankyou__inner` div; the image tag uses `src="./assets/reviews/pawsh-100-axiologiseis-google-galatsi.webp"`, `loading="lazy"`, and the provided alt text `Pawsh 100 αξιολογήσεις Google στο Γαλάτσι - καλλωπισμός σκύλων Αθήνα`.
- Added a minimal `.reviews-celebration-image` CSS block to the existing stylesheet in `index.html` to center the image, cap desktop width at `240px`, allow full-width responsiveness on mobile, and add subtle rounding.
- Only `index.html` was modified; no JavaScript, popup logic, thank-you text, SEO/head/meta, URLs, sitemap, or robots changes were made.

### Testing
- Verified the insertion and styling via `rg -n "reviews-celebration-image|pawsh-100-axiologiseis" index.html` which found the new class and image path, and `nl` confirmed the image sits directly after the CTA link; these checks succeeded.
- Committed the change with a descriptive message and confirmed `git status` showed the file update; commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f04c15148320b0c787d3b30720b6)