### PR TITLE
Refine homepage trust popup timing and celebration image UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,7 +324,7 @@
 
     .reviews-celebration-image {
       display: block;
-      max-width: 240px;
+      max-width: 360px;
       width: 100%;
       margin: 20px auto 0;
       border-radius: 12px;
@@ -610,12 +610,14 @@
     <h3>100+ αξιολογήσεις στο Google</h3>
     <p>Σας ευχαριστούμε για την εμπιστοσύνη! Το Pawsh Pet Beauty Salon ξεπέρασε τις 100 αξιολογήσεις στο Google με βαθμολογία 5.0. Η αγάπη και η στήριξή σας μάς δίνουν δύναμη να προσφέρουμε καθημερινά προσεγμένη, ήρεμη και επαγγελματική φροντίδα σε κάθε κατοικίδιο.</p>
     <a href="https://www.google.com/maps/search/?api=1&query=Pawsh%20Pet%20Beauty%20Salon%2C%20Agias%20Glykerias%2062%2C%20Galatsi" class="hero-cta hero-cta-secondary" target="_blank" rel="noopener">Δες όλες τις αξιολογήσεις στο Google</a>
-    <img 
-      src="./assets/reviews/pawsh-100-axiologiseis-google-galatsi.webp"
-      alt="Pawsh 100 αξιολογήσεις Google στο Γαλάτσι - καλλωπισμός σκύλων Αθήνα"
-      class="reviews-celebration-image"
-      loading="lazy"
-    >
+    <a href="./assets/reviews/pawsh-100-axiologiseis-google-galatsi.webp" target="_blank" rel="noopener" aria-label="Άνοιγμα εικόνας 100 αξιολογήσεων Pawsh σε μεγαλύτερο μέγεθος">
+      <img 
+        src="./assets/reviews/pawsh-100-axiologiseis-google-galatsi.webp"
+        alt="Pawsh 100 αξιολογήσεις Google στο Γαλάτσι - καλλωπισμός σκύλων Αθήνα"
+        class="reviews-celebration-image"
+        loading="lazy"
+      >
+    </a>
   </div>
 </section>
 
@@ -754,8 +756,8 @@
     const trustPopupClose = document.getElementById('trust-popup-close');
     if (trustPopup && trustPopupClose) {
       const popupStorageKey = 'pawsh_trust_popup_seen';
-      const popupDelayMs = 5000;
-      const popupScrollThreshold = 0.35;
+      const popupDelayMs = 2500;
+      const popupScrollThreshold = 0.15;
       let popupShown = false;
 
       const popupStorageAvailable = (() => {


### PR DESCRIPTION
### Motivation
- Make the 100+ Google reviews popup appear sooner so visitors see the trust signal earlier. 
- Improve visibility and discoverability of the celebration image in the thank-you/reviews section without changing layout or content. 

### Description
- Updated the popup timing constants in `index.html`: `popupDelayMs` changed from `5000` to `2500` and `popupScrollThreshold` changed from `0.35` to `0.15`, while keeping the existing `pawsh_trust_popup_seen` one-time storage logic and close/CTA behavior intact. 
- Increased the celebration image display size by changing `.reviews-celebration-image` `max-width` from `240px` to `360px` and preserving `width: 100%` for mobile responsiveness and existing `border-radius` and spacing. 
- Made the celebration image clickable by wrapping it in an anchor linking to `./assets/reviews/pawsh-100-axiologiseis-google-galatsi.webp` with `target="_blank"` and `rel="noopener"`, and added the `aria-label` `Άνοιγμα εικόνας 100 αξιολογήσεων Pawsh σε μεγαλύτερο μέγεθος`, while leaving the image `alt` text unchanged. 
- Confined changes to `index.html` only and did not modify SEO/head/meta/schema/canonical/hreflang/sitemap/robots, navigation, hero layout, cookie banner logic, or introduce new libraries or lightbox behavior. 

### Testing
- Searched and validated occurrences with `rg -n "pawsh_trust_popup_seen|popupDelayMs|popupScrollThreshold|reviews-celebration-image|pawsh-100-axiologiseis-google-galatsi.webp"` and confirmed updated values; command completed successfully. 
- Reviewed the inline diff with `git diff -- index.html` to confirm the `popupDelayMs`, `popupScrollThreshold`, `max-width` change, and image wrapper insertion; diff inspection succeeded. 
- Committed the change with `git commit` as a final step; the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f506c2d0408320adf5d296b311c553)