### PR TITLE
Replace trust popup with image-based reviews modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -625,13 +625,30 @@
     </section>
 
 
-  <div id="trust-popup" class="trust-popup" role="dialog" aria-labelledby="trust-popup-title" aria-describedby="trust-popup-text" aria-live="polite" aria-hidden="true">
-    <button type="button" class="trust-popup__close" id="trust-popup-close" aria-label="Κλείσιμο">×</button>
-    <h3 id="trust-popup-title">Σας ευχαριστούμε! 🐾</h3>
-    <p id="trust-popup-text">Ξεπεράσαμε τις 100 αξιολογήσεις στο Google με βαθμολογία 5.0. Η εμπιστοσύνη σας είναι η μεγαλύτερη επιβράβευση για εμάς.</p>
-    <div class="trust-popup__actions">
-      <a href="https://www.google.com/maps/search/?api=1&query=Pawsh%20Pet%20Beauty%20Salon%2C%20Agias%20Glykerias%2062%2C%20Galatsi" class="hero-cta hero-cta-secondary" target="_blank" rel="noopener">Δες αξιολογήσεις</a>
-      <a href="https://pawshpetbeautysalon.setmore.com" class="hero-cta" target="_blank" rel="noopener">Κλείσε ραντεβού</a>
+  <div id="reviews-popup" class="reviews-popup">
+    <div class="reviews-popup-card">
+      <button class="reviews-popup-close" aria-label="Κλείσιμο">×</button>
+
+      <img 
+        src="./assets/reviews/pawsh-100-axiologiseis-google-galatsi.webp"
+        alt="Pawsh 100 αξιολογήσεις Google στο Γαλάτσι - καλλωπισμός σκύλων Αθήνα"
+        loading="lazy"
+      />
+
+      <div class="reviews-popup-content">
+        <h3>Σας ευχαριστούμε! 🐾</h3>
+        <p>100+ αξιολογήσεις στο Google με βαθμολογία 5.0 ⭐</p>
+
+        <div class="reviews-popup-actions">
+          <a href="https://g.page/r/YOUR-GOOGLE-LINK/review" class="btn-primary">
+            Δες αξιολογήσεις
+          </a>
+          <a href="/contact.html" class="btn-secondary">
+            Κλείσε ραντεβού
+          </a>
+        </div>
+      </div>
+
     </div>
   </div>
 
@@ -750,72 +767,47 @@
     }
 
 
-    const trustPopup = document.getElementById('trust-popup');
-    const trustPopupClose = document.getElementById('trust-popup-close');
-    if (trustPopup && trustPopupClose) {
-      const popupStorageKey = 'pawsh_trust_popup_seen';
-      const popupDelayMs = 5000;
-      const popupScrollThreshold = 0.35;
-      let popupShown = false;
+    document.addEventListener("DOMContentLoaded", () => {
+      const popup = document.getElementById("reviews-popup");
+      const cookieBanner = document.getElementById('cookie-banner');
 
-      const popupStorageAvailable = (() => {
-        try {
-          const testKey = '__pawsh_trust_popup_test__';
-          localStorage.setItem(testKey, '1');
-          localStorage.removeItem(testKey);
-          return true;
-        } catch (error) {
-          return false;
-        }
-      })();
+      if (!popup) return;
+      if (localStorage.getItem("pawsh_reviews_popup_seen")) return;
 
-      const popupAlreadySeen = popupStorageAvailable && localStorage.getItem(popupStorageKey) === 'true';
+      const showPopup = () => popup.classList.add("active");
 
-      const hidePopup = () => {
-        trustPopup.classList.remove('is-visible');
-        trustPopup.setAttribute('aria-hidden', 'true');
-        if (popupStorageAvailable) {
-          localStorage.setItem(popupStorageKey, 'true');
-        }
+      const showWithDelay = () => {
+        setTimeout(() => {
+          if (!cookieBanner || !cookieBanner.classList.contains('is-visible')) {
+            showPopup();
+          }
+        }, 2500);
       };
 
-      const showPopup = () => {
-        if (popupShown || popupAlreadySeen) {
-          return;
-        }
-        popupShown = true;
-        trustPopup.classList.add('is-visible');
-        trustPopup.setAttribute('aria-hidden', 'false');
-        window.removeEventListener('scroll', onPopupScroll);
-      };
-
-      const onPopupScroll = () => {
-        const scrollableHeight = document.documentElement.scrollHeight - window.innerHeight;
-        if (scrollableHeight <= 0) {
-          return;
-        }
-        const scrollRatio = window.scrollY / scrollableHeight;
-        if (scrollRatio >= popupScrollThreshold) {
-          showPopup();
-        }
-      };
-
-      if (!popupAlreadySeen) {
-        const popupTimer = window.setTimeout(showPopup, popupDelayMs);
-        window.addEventListener('scroll', onPopupScroll, { passive: true });
-        trustPopupClose.addEventListener('click', () => {
-          window.clearTimeout(popupTimer);
-          hidePopup();
+      if (cookieBanner && cookieBanner.classList.contains('is-visible')) {
+        const observer = new MutationObserver(() => {
+          if (!cookieBanner.classList.contains('is-visible')) {
+            observer.disconnect();
+            showWithDelay();
+          }
         });
-
-        trustPopup.querySelectorAll('a').forEach((link) => {
-          link.addEventListener('click', () => {
-            window.clearTimeout(popupTimer);
-            hidePopup();
-          });
-        });
+        observer.observe(cookieBanner, { attributes: true, attributeFilter: ['class'] });
+      } else {
+        showWithDelay();
       }
-    }
+
+      popup.querySelector(".reviews-popup-close").addEventListener("click", () => {
+        popup.classList.remove("active");
+        localStorage.setItem("pawsh_reviews_popup_seen", "true");
+      });
+
+      popup.addEventListener("click", (e) => {
+        if (e.target === popup) {
+          popup.classList.remove("active");
+          localStorage.setItem("pawsh_reviews_popup_seen", "true");
+        }
+      });
+    });
 
     const cookieBanner = document.getElementById('cookie-banner');
     const cookieAccept = document.getElementById('cookie-accept');

--- a/style.css
+++ b/style.css
@@ -1788,81 +1788,64 @@ footer a {
   line-height: 1.65;
 }
 
-.trust-popup {
+
+
+.reviews-popup {
   position: fixed;
-  right: 1rem;
-  bottom: 1rem;
-  z-index: 70;
-  width: min(360px, calc(100% - 2rem));
-  background: rgba(255, 255, 255, 0.96);
-  border: 1px solid rgba(6, 61, 73, 0.16);
-  border-radius: 14px;
-  box-shadow: 0 16px 38px rgba(6, 61, 73, 0.22);
-  padding: 1rem;
+  inset: 0;
+  background: rgba(0,0,0,0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
   opacity: 0;
-  transform: translateY(10px);
   pointer-events: none;
-  transition: opacity 0.28s ease, transform 0.28s ease;
+  transition: opacity 0.3s ease;
 }
 
-.trust-popup.is-visible {
+.reviews-popup.active {
   opacity: 1;
-  transform: translateY(0);
-  pointer-events: auto;
+  pointer-events: all;
 }
 
-.trust-popup h3 {
-  margin: 0 1.8rem 0.4rem 0;
-  color: var(--accent);
-  font-size: 1.12rem;
+.reviews-popup-card {
+  background: #fff;
+  border-radius: 16px;
+  max-width: 360px;
+  width: 90%;
+  padding: 16px;
+  text-align: center;
+  position: relative;
+  animation: popupFade 0.4s ease;
 }
 
-.trust-popup p {
-  margin: 0 0 0.85rem;
-  color: var(--secondary);
-  line-height: 1.5;
-  font-size: 0.95rem;
+.reviews-popup-card img {
+  width: 100%;
+  border-radius: 12px;
+  margin-bottom: 12px;
 }
 
-.trust-popup__close {
+.reviews-popup-close {
   position: absolute;
-  top: 0.4rem;
-  right: 0.45rem;
-  border: 0;
+  top: 10px;
+  right: 12px;
+  border: none;
   background: transparent;
-  color: var(--accent);
-  font-size: 1.35rem;
-  line-height: 1;
+  font-size: 20px;
   cursor: pointer;
 }
 
-.trust-popup__actions {
+.reviews-popup-actions {
   display: flex;
-  gap: 0.55rem;
-  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 12px;
 }
 
-.trust-popup__actions .hero-cta {
-  margin-top: 0;
-  min-width: auto;
-  padding: 0.55rem 0.9rem;
-  font-size: 0.92rem;
+.reviews-popup-actions a {
+  flex: 1;
 }
 
-@media (max-width: 640px) {
-  .trust-popup {
-    right: 0.75rem;
-    left: 0.75rem;
-    width: auto;
-    bottom: 0.75rem;
-  }
-
-  .trust-popup__actions {
-    flex-direction: column;
-  }
-
-  .trust-popup__actions .hero-cta {
-    width: 100%;
-    justify-content: center;
-  }
+@keyframes popupFade {
+  from { transform: translateY(20px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
 }


### PR DESCRIPTION
### Motivation
- Replace the small legacy trust popup with a clean, image-based reviews modal that feels premium, mobile-friendly and places CTAs below the review image while avoiding interference with the cookie banner.

### Description
- Removed the old `#trust-popup` markup, its related JS storage key and behavior, and legacy `.trust-popup` styles. 
- Added the new `#reviews-popup` HTML block before `</body>` containing the review image, close button, thank-you copy and two CTA links as requested. 
- Added modal styling to `style.css` for `.reviews-popup`, `.reviews-popup-card`, `.reviews-popup-close` and `.reviews-popup-actions` including an entrance animation and mobile-friendly sizing. 
- Injected JS that shows the popup after 2.5s (unless `pawsh_reviews_popup_seen` is set), persists dismissal to `localStorage`, supports outside-click to close, and delays showing while the cookie banner is visible via a `MutationObserver` to avoid simultaneous overlays. 

### Testing
- Verified removal and addition of selectors with a code search using `rg -n "trust-popup|pawsh_trust_popup_seen|reviews-popup|pawsh_reviews_popup_seen" index.html style.css` which showed the new selectors and no remaining old selectors. 
- Inspected updated files (`index.html`, `style.css`) to confirm the new HTML block, JS logic and CSS rules are present. 
- Confirmed the new popup logic uses `localStorage` key `pawsh_reviews_popup_seen` and coordinates with the cookie banner; no automated visual tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50774bc7c832092d54abb43321325)