### PR TITLE
Upgrade homepage gallery to responsive premium grid with vanilla lightbox and CTA

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -52,54 +52,52 @@ document.addEventListener('DOMContentLoaded', () => {
     return;
   }
 
-  const altTextMap = new Map([
-    [1, 'Σκύλος 1'],
-    [2, 'Σκύλος 2'],
-    [3, 'Σκύλος 3'],
-    [4, 'Σκύλος 4'],
-    [8, 'Σκύλος 8'],
-    [9, 'Σκύλος 9'],
-    [10, 'Σκύλος 10'],
-    [11, 'Σκύλος 11'],
-    [12, 'Σκύλος 12'],
-    [13, 'Σκύλος 13'],
-    [14, 'Σκύλος 14'],
-    [15, 'Σκύλος 15'],
-    [16, 'Σκύλος 16'],
-    [17, 'Σκύλος 17'],
-    [18, 'Σκύλος 18'],
-    [19, 'Σκύλος 19'],
-    [20, 'Σκύλος 20'],
-    [21, 'Σκύλος 21'],
-    [22, 'Σκύλος 22'],
-    [23, 'Σκύλος 23'],
-    [24, 'Σκύλος 24'],
-    [25, 'Σκύλος 25'],
-    [26, 'Σκύλος 26'],
-    [27, 'Σκύλος 27'],
-    [28, 'Σκύλος 28'],
-    [29, 'Σκύλος 29'],
-    [30, 'Σκύλος 30'],
-    [31, 'Σκύλος 31'],
-    [32, 'Σκύλος 32'],
-    [33, 'Σκύλος 33'],
-    [34, 'Σκύλος 34'],
-    [35, 'Σκύλος 35'],
-    [36, 'Σκύλος 36'],
-    [37, 'Σκύλος 37'],
-  ]);
+  const galleryImages = [
+    { src: 'assets/images/dogs/pet-grooming-galatsi-mixed-dog-bandana.webp.webp', alt: 'καλλωπισμός σκύλου στο Pawsh Pet Grooming Γαλάτσι με μπαντάνα' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-akita-xalarosi.webp.webp', alt: 'χαλαρός σκύλος μετά από περιποίηση στο Pawsh Γαλάτσι' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-labrador-retriever.webp.webp', alt: 'κούρεμα και φροντίδα labrador στο Pawsh Pet Grooming' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-leykos-skylos-kanapes.webp.webp', alt: 'λευκός σκύλος σε καναπέ μετά το grooming στο Pawsh' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-husky-bandana.webp.webp', alt: 'husky με μπαντάνα μετά από καλλωπισμό σκύλου στο Pawsh' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-three-dogs-group.webp.webp', alt: 'τρία σκυλάκια μετά από περιποίηση σκύλου στο Pawsh Pet Grooming' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-staffordshire-xamogelo.webp.webp', alt: 'χαμογελαστός σκύλος μετά από grooming στο Pawsh Γαλάτσι' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-poodle-beige-fiogkos.webp.webp', alt: 'poodle με φιόγκο μετά από καλλωπισμό σκύλου στο Pawsh' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-mikros-skylos-bandana-kokkini.webp.webp', alt: 'μικρός σκύλος με κόκκινη μπαντάνα στο Pawsh Pet Grooming' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-pomeranian-bowtie.webp.webp', alt: 'κούρεμα σκύλου pomeranian στο Pawsh Γαλάτσι' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-corgi-mix.webp.webp', alt: 'περιποίηση σκύλου corgi mix στο Pawsh' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-french-bulldog-kanapes.webp.webp', alt: 'french bulldog σε καναπέ μετά από grooming στο Pawsh' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-german-shepherd.webp.webp', alt: 'γερμανικός ποιμενικός μετά από καλλωπισμό στο Pawsh Pet Grooming' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-spitz-leyko-kourema.webp.webp', alt: 'κούρεμα σκύλου spitz στο Pawsh Γαλάτσι' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-german-shepherd-kanapes.webp.webp', alt: 'περιποίηση σκύλου german shepherd στο Pawsh' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-german-shepherd-mix.webp.webp', alt: 'german shepherd mix μετά από περιποίηση στο Pawsh Pet Grooming' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-mikros-skylos-aspro-mavro.webp.webp', alt: 'ασπρόμαυρος μικρός σκύλος μετά από grooming στο Pawsh' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-beagle-bandana.webp.webp', alt: 'beagle με μπαντάνα μετά από καλλωπισμό σκύλου στο Pawsh' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-large-mixed-dog-sofa.webp.webp', alt: 'μεγάλος σκύλος σε καναπέ μετά από περιποίηση στο Pawsh Γαλάτσι' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-german-shepherd-xalarosi.webp.webp', alt: 'χαλαρός γερμανικός ποιμενικός μετά από grooming στο Pawsh' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-black-mixed-dog.webp.webp', alt: 'μαύρος mixed σκύλος μετά από καλλωπισμό στο Pawsh Pet Grooming' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-maltese-roz-koritsaki.webp.webp', alt: 'maltese με ροζ αξεσουάρ μετά από κούρεμα σκύλου στο Pawsh' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-pitbull-blue-sofa.webp.webp', alt: 'pitbull σε μπλε καναπέ μετά από περιποίηση στο Pawsh' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-cocker-spaniel-kallopismos.webp.webp', alt: 'καλλωπισμός cocker spaniel στο Pawsh Pet Grooming Γαλάτσι' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-pomeranian-fiogkos-mavros.webp.webp', alt: 'pomeranian με μαύρο φιόγκο μετά από grooming στο Pawsh' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-megalos-skylos-kanapes-mple.webp.webp', alt: 'μεγάλος σκύλος μετά από περιποίηση σκύλου στο Pawsh' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-spitz-leyko-fiogkos.webp.webp', alt: 'λευκό spitz με φιόγκο στο Pawsh Pet Grooming' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-large-black-dog-sofa.webp.webp', alt: 'μαύρος μεγάλος σκύλος σε καναπέ μετά από καλλωπισμό στο Pawsh' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-golden-retriever-kanapes.webp.webp', alt: 'golden retriever μετά από grooming στο Pawsh Γαλάτσι' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-pomeranian-sofa.webp.webp', alt: 'περιποίηση σκύλου pomeranian στο Pawsh Pet Grooming' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-pug-blue-sofa.webp.webp', alt: 'κούρεμα σκύλου pug στο Pawsh Γαλάτσι' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-yorkshire-terrier-bowtie.webp.webp', alt: 'yorkshire terrier μετά από καλλωπισμό στο Pawsh' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-mixed-dog-colorful-bandana.webp.webp', alt: 'σκύλος με πολύχρωμη μπαντάνα μετά από περιποίηση στο Pawsh' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-megalos-skylos-kanapes-kafe.webp.webp', alt: 'μεγάλος σκύλος σε καφέ καναπέ μετά από grooming στο Pawsh' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-black-white-small-dog-bow.webp.webp', alt: 'μικρός ασπρόμαυρος σκύλος με φιόγκο στο Pawsh Pet Grooming' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-poodle-kourema-fiogkos.webp.webp', alt: 'κούρεμα poodle με φιόγκο στο Pawsh Γαλάτσι' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-poodle-kafe-kourema.webp.webp', alt: 'καφέ poodle μετά από περιποίηση σκύλου στο Pawsh' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-golden-mixed-dog.webp.webp', alt: 'golden mixed σκύλος μετά από καλλωπισμό στο Pawsh Pet Grooming' },
+    { src: 'assets/images/dogs/pet-grooming-galatsi-fluffy-brown-dog.webp.webp', alt: 'αφράτος καφέ σκύλος μετά από grooming στο Pawsh Γαλάτσι' }
+  ];
 
   const slidesData = [];
   const slides = [];
-  const totalImages = 37;
-  const imageFilePrefix = 'dog';
-  const galleryPathPrefix = (gallerySection.dataset.galleryPathPrefix || '.').replace(/\/$/, '');
 
-  for (let i = 1; i <= totalImages; i += 1) {
-    const imageFileName = `${imageFilePrefix}${i}.jpg`;
-    const imageSrc = `${galleryPathPrefix}/dogs/${imageFileName}`;
-    const imageAlt = altTextMap.get(i) || `Pawsh gallery photo ${i}`;
-
+  galleryImages.forEach(({ src, alt }, index) => {
     const slide = document.createElement('div');
     slide.className = 'pawsh-gallery-slide';
     slide.setAttribute('role', 'listitem');
@@ -107,24 +105,22 @@ document.addEventListener('DOMContentLoaded', () => {
     const button = document.createElement('button');
     button.type = 'button';
     button.className = 'pawsh-gallery-slide-button';
-    button.setAttribute('aria-label', `Μεγέθυνση: ${imageAlt}`);
+    button.setAttribute('aria-label', `Μεγέθυνση: ${alt}`);
 
     const img = document.createElement('img');
-    img.src = imageSrc;
-    img.alt = imageAlt;
+    img.src = src;
+    img.alt = alt;
     img.decoding = 'async';
     img.draggable = false;
-    if (i > 3) {
-      img.loading = 'lazy';
-    }
+    img.loading = index > 3 ? 'lazy' : 'eager';
 
     button.appendChild(img);
     slide.appendChild(button);
     track.appendChild(slide);
 
-    slidesData.push({ src: imageSrc, alt: imageAlt });
+    slidesData.push({ src, alt });
     slides.push({ slide, button });
-  }
+  });
 
   if (!slides.length) {
     return;

--- a/index.html
+++ b/index.html
@@ -476,9 +476,14 @@
 <h2 class="pawsh-gallery-heading">Pawsh Models</h2>
 <section id="gallery" class="pawsh-gallery-section" aria-label="Γκαλερί σκύλων">
   <div class="pawsh-gallery-container">
-    <div class="pawsh-gallery-scroller" tabindex="0" aria-label="Συλλογή φωτογραφιών Pawsh" role="list">
+    <div class="pawsh-gallery-scroller" aria-label="Συλλογή φωτογραφιών Pawsh" role="list">
       <div class="pawsh-gallery-track"></div>
     </div>
+    <article class="pawsh-gallery-cta" aria-label="Κάλεσμα για ραντεβού">
+      <p class="cta-lead">Θες και ο σκύλος σου να δείχνει έτσι;</p>
+      <p>Κλείσε ραντεβού στο Pawsh Pet Grooming</p>
+      <a href="https://pawshpetbeautysalon.setmore.com" class="pawsh-gallery-cta-button" target="_blank" rel="noopener">Κλείσε Ραντεβού</a>
+    </article>
   </div>
   <div class="pawsh-gallery-lightbox" aria-hidden="true" role="dialog" aria-modal="true" hidden>
     <button type="button" class="pawsh-gallery-lightbox-close" aria-label="Κλείσιμο gallery">&times;</button>

--- a/style.css
+++ b/style.css
@@ -1060,12 +1060,12 @@ footer img.logo {
   font-size: clamp(2rem, 5vw, 2.75rem);
   color: #063d49;
   font-weight: 700;
-  margin: 4rem auto 1.5rem;
+  margin: 4rem auto 1.25rem;
   padding: 0 1rem;
 }
 
 .pawsh-gallery-section {
-  padding: 3rem 0;
+  padding: 2.5rem 1rem 3rem;
 }
 
 .pawsh-gallery-container {
@@ -1074,82 +1074,90 @@ footer img.logo {
 }
 
 .pawsh-gallery-scroller {
-  --pawsh-gallery-gap: 1.5rem;
-  position: relative;
-  height: 260px;
-  overflow-x: auto;
-  overflow-y: hidden;
-  scroll-snap-type: x mandatory;
-  scroll-behavior: smooth;
-  scroll-padding-inline: var(--pawsh-gallery-gap);
-  padding: 1rem var(--pawsh-gallery-gap);
-  -webkit-overflow-scrolling: touch;
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.35);
-  backdrop-filter: blur(6px);
-}
-
-.pawsh-gallery-scroller::-webkit-scrollbar {
-  height: 8px;
-}
-
-.pawsh-gallery-scroller::-webkit-scrollbar-thumb {
-  background: rgba(6, 61, 73, 0.35);
-  border-radius: 999px;
-}
-
-.pawsh-gallery-scroller::-webkit-scrollbar-track {
-  background: transparent;
+  margin: 0;
 }
 
 .pawsh-gallery-track {
   display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: calc((100% - (var(--pawsh-gallery-gap) * 2)) / 3);
-  gap: var(--pawsh-gallery-gap);
-  height: 100%;
-  align-items: center;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+  gap: 0.85rem;
 }
 
 .pawsh-gallery-slide {
   position: relative;
-  height: 100%;
-  scroll-snap-align: center;
-  scroll-snap-stop: always;
   border-radius: 14px;
   overflow: hidden;
-  transform: scale(0.98);
-  transition: transform 0.4s ease, box-shadow 0.4s ease;
-  box-shadow: 0 10px 24px rgba(6, 61, 73, 0.18);
-  background: rgba(255, 255, 255, 0.55);
-  display: flex;
-}
-
-.pawsh-gallery-slide.is-active {
-  transform: scale(1.06);
-  box-shadow: 0 24px 48px rgba(6, 61, 73, 0.35);
+  background: #f3eee3;
+  box-shadow: 0 8px 18px rgba(6, 61, 73, 0.14);
 }
 
 .pawsh-gallery-slide-button {
   width: 100%;
-  height: 100%;
   border: none;
-  background: none;
   padding: 0;
-  cursor: pointer;
+  background: transparent;
   display: block;
+  cursor: pointer;
+  position: relative;
+}
+
+.pawsh-gallery-slide-button::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(6, 61, 73, 0.35), rgba(6, 61, 73, 0));
+  opacity: 0;
+  transition: opacity 0.3s ease;
 }
 
 .pawsh-gallery-slide-button:focus-visible {
   outline: 3px solid #d7c9a9;
-  outline-offset: 4px;
+  outline-offset: 3px;
 }
 
 .pawsh-gallery-slide img {
   width: 100%;
   height: 100%;
+  min-height: 180px;
   object-fit: cover;
   display: block;
+  transition: transform 0.45s ease;
+}
+
+@media (hover: hover) {
+  .pawsh-gallery-slide-button:hover img,
+  .pawsh-gallery-slide-button:focus-visible img {
+    transform: scale(1.06);
+  }
+
+  .pawsh-gallery-slide-button:hover::after,
+  .pawsh-gallery-slide-button:focus-visible::after {
+    opacity: 1;
+  }
+}
+
+.pawsh-gallery-cta {
+  margin: 1.25rem auto 0;
+  max-width: 520px;
+  background: linear-gradient(135deg, #063d49, #0c5565);
+  color: #fefaf1;
+  border-radius: 16px;
+  padding: 1rem 1.1rem;
+  text-align: center;
+}
+
+.pawsh-gallery-cta p { margin: 0 0 0.4rem; }
+.pawsh-gallery-cta .cta-lead { font-weight: 700; font-size: 1.1rem; }
+
+.pawsh-gallery-cta-button {
+  display: inline-block;
+  margin-top: 0.4rem;
+  background: #d7c9a9;
+  color: #063d49;
+  text-decoration: none;
+  font-weight: 700;
+  border-radius: 999px;
+  padding: 0.55rem 1.2rem;
 }
 
 .pawsh-gallery-lightbox {
@@ -1158,152 +1166,34 @@ footer img.logo {
   display: none;
   align-items: center;
   justify-content: center;
-  gap: 2rem;
-  padding: 2rem;
-  background: rgba(6, 61, 73, 0.92);
-  backdrop-filter: blur(8px);
-  z-index: 1000;
-  opacity: 0;
-  visibility: hidden;
-  transition: opacity 0.3s ease;
-}
-
-.pawsh-gallery-lightbox[hidden] {
-  display: none;
-}
-
-.pawsh-gallery-lightbox:not([hidden]) {
-  display: flex;
-  opacity: 1;
-  visibility: visible;
-}
-
-.pawsh-gallery-lightbox-figure {
-  max-width: min(90vw, 960px);
-  max-height: 80vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
   gap: 1rem;
-  text-align: center;
-  color: #f4f0e4;
+  padding: 1.25rem;
+  background: rgba(3, 18, 22, 0.9);
+  z-index: 1000;
+}
+.pawsh-gallery-lightbox[hidden] { display: none; }
+.pawsh-gallery-lightbox:not([hidden]) { display: flex; }
+.pawsh-gallery-lightbox-figure { max-width: min(92vw, 980px); margin: 0; }
+.pawsh-gallery-lightbox-image { width: 100%; max-height: 78vh; object-fit: contain; border-radius: 14px; }
+.pawsh-gallery-lightbox-caption { color: #fff; text-align: center; margin-top: 0.6rem; }
+.pawsh-gallery-lightbox-control, .pawsh-gallery-lightbox-close { cursor:pointer; }
+
+body.pawsh-gallery-no-scroll { overflow: hidden; }
+
+@media (min-width: 430px) {
+  .pawsh-gallery-track { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
-.pawsh-gallery-lightbox-image {
-  width: 100%;
-  max-height: 70vh;
-  object-fit: contain;
-  border-radius: 16px;
-  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.35);
-}
-
-.pawsh-gallery-lightbox-caption {
-  font-size: 1rem;
-  line-height: 1.4;
-  color: #fefaf1;
-}
-
-.pawsh-gallery-lightbox-control {
-  width: 3.25rem;
-  height: 3.25rem;
-  border-radius: 999px;
-  border: none;
-  background: rgba(215, 201, 169, 0.9);
-  color: #063d49;
-  display: grid;
-  place-items: center;
-  font-size: 1.75rem;
-  cursor: pointer;
-  transition: transform 0.3s ease, background 0.3s ease;
-}
-
-.pawsh-gallery-lightbox-control:hover,
-.pawsh-gallery-lightbox-control:focus-visible {
-  background: rgba(250, 242, 220, 1);
-  transform: scale(1.05);
-  outline: none;
-}
-
-.pawsh-gallery-lightbox-close {
-  position: absolute;
-  top: 1.5rem;
-  right: 1.5rem;
-  width: 3rem;
-  height: 3rem;
-  border-radius: 999px;
-  border: none;
-  background: rgba(255, 255, 255, 0.2);
-  color: #ffffff;
-  font-size: 2rem;
-  cursor: pointer;
-  display: grid;
-  place-items: center;
-  transition: background 0.3s ease, transform 0.3s ease;
-}
-
-.pawsh-gallery-lightbox-close:hover,
-.pawsh-gallery-lightbox-close:focus-visible {
-  background: rgba(255, 255, 255, 0.35);
-  transform: scale(1.05);
-  outline: none;
-}
-
-body.pawsh-gallery-no-scroll {
-  overflow: hidden;
-}
-
-@media (min-width: 1024px) {
-  .pawsh-gallery-scroller {
-    height: 320px;
-  }
-}
-
-@media (max-width: 920px) {
-  .pawsh-gallery-scroller {
-    height: 220px;
-    --pawsh-gallery-gap: 1.25rem;
-  }
-
+@media (min-width: 768px) {
   .pawsh-gallery-track {
-    grid-auto-columns: calc((100% - var(--pawsh-gallery-gap)) / 2);
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-auto-flow: dense;
   }
+  .pawsh-gallery-slide:nth-child(5n) { grid-row: span 2; }
 }
 
-@media (max-width: 640px) {
-  .pawsh-gallery-section {
-    padding: 2.5rem 0;
-  }
-
-  .pawsh-gallery-scroller {
-    height: calc(100vw - 2rem);
-    padding-inline: 1rem;
-    --pawsh-gallery-gap: 1rem;
-  }
-
-  .pawsh-gallery-track {
-    grid-auto-columns: 100%;
-    align-items: stretch;
-  }
-
-  .pawsh-gallery-slide {
-    height: auto;
-    aspect-ratio: 1 / 1;
-  }
-
-  .pawsh-gallery-lightbox {
-    padding: 1.5rem;
-    gap: 1.25rem;
-  }
-
-  .pawsh-gallery-lightbox-control {
-    width: 2.75rem;
-    height: 2.75rem;
-    font-size: 1.5rem;
-  }
-
-  .pawsh-gallery-lightbox-caption {
-    font-size: 0.95rem;
-  }
+@media (min-width: 1200px) {
+  .pawsh-gallery-track { grid-template-columns: repeat(4, minmax(0, 1fr)); }
 }
 
 .cookie-banner {


### PR DESCRIPTION
### Motivation
- Improve the existing homepage gallery to feel more premium and conversion-focused while keeping all other parts of the homepage untouched. 
- Provide a mobile-first responsive gallery and a lightweight accessible lightbox without adding external libraries. 
- Add a single non-intrusive Greek CTA to drive bookings while preserving existing booking links and SEO constraints.

### Description
- Replaced the old gallery population logic and generic image references with an explicit list of existing assets and descriptive Greek `alt` text in `assets/js/main.js`, preserving `loading="lazy"` for non-critical images and keeping the vanilla lightbox behavior (open/close, ESC, arrow keys, click outside, prev/next). 
- Reworked gallery styling in `style.css` to a mobile-first responsive grid (1 column very small, 2 columns on mobile when space allows, 3 columns on tablet, 4 columns on desktop), added subtle hover zoom and soft overlay transitions, and scoped styles to `.pawsh-gallery-*` classes only. 
- Inserted one small CTA card (Greek text) inside the gallery container in `index.html` linking to the existing `setmore` booking link; CTA copy and button use the provided Greek phrases. 
- Modified files: `index.html`, `style.css`, `assets/js/main.js`. 
- Fixed previous broken/incorrect gallery reference pattern (old `./dogs/dogN.jpg` style) by pointing to repository assets under `assets/images/dogs/` without renaming or moving any image files.

### Testing
- Verified image paths referenced in `assets/js/main.js` exist with a script (`python` check) and reported `missing = 0`, so all gallery images are present. (succeeded) 
- Confirmed the homepage references to CSS and JS remain unchanged and only gallery-related files were modified using `rg`/`git status`. (succeeded) 
- Committed changes successfully to the repository (no failures reported). (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f76b1cfe90832097056cb0d80a82a4)