### PR TITLE
Fix homepage gallery images and add compact preview carousel

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -37,6 +37,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const scroller = gallerySection.querySelector('.pawsh-gallery-scroller');
   const track = gallerySection.querySelector('.pawsh-gallery-track');
   const lightbox = gallerySection.querySelector('.pawsh-gallery-lightbox');
+  const galleryPrevButton = gallerySection.querySelector('.pawsh-gallery-nav-prev');
+  const galleryNextButton = gallerySection.querySelector('.pawsh-gallery-nav-next');
 
   if (!scroller || !track || !lightbox) {
     return;
@@ -53,45 +55,14 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const galleryImages = [
-    { src: 'assets/images/dogs/pet-grooming-galatsi-mixed-dog-bandana.webp.webp', alt: 'καλλωπισμός σκύλου στο Pawsh Pet Grooming Γαλάτσι με μπαντάνα' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-akita-xalarosi.webp.webp', alt: 'χαλαρός σκύλος μετά από περιποίηση στο Pawsh Γαλάτσι' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-labrador-retriever.webp.webp', alt: 'κούρεμα και φροντίδα labrador στο Pawsh Pet Grooming' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-leykos-skylos-kanapes.webp.webp', alt: 'λευκός σκύλος σε καναπέ μετά το grooming στο Pawsh' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-husky-bandana.webp.webp', alt: 'husky με μπαντάνα μετά από καλλωπισμό σκύλου στο Pawsh' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-three-dogs-group.webp.webp', alt: 'τρία σκυλάκια μετά από περιποίηση σκύλου στο Pawsh Pet Grooming' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-staffordshire-xamogelo.webp.webp', alt: 'χαμογελαστός σκύλος μετά από grooming στο Pawsh Γαλάτσι' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-poodle-beige-fiogkos.webp.webp', alt: 'poodle με φιόγκο μετά από καλλωπισμό σκύλου στο Pawsh' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-mikros-skylos-bandana-kokkini.webp.webp', alt: 'μικρός σκύλος με κόκκινη μπαντάνα στο Pawsh Pet Grooming' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-pomeranian-bowtie.webp.webp', alt: 'κούρεμα σκύλου pomeranian στο Pawsh Γαλάτσι' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-corgi-mix.webp.webp', alt: 'περιποίηση σκύλου corgi mix στο Pawsh' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-french-bulldog-kanapes.webp.webp', alt: 'french bulldog σε καναπέ μετά από grooming στο Pawsh' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-german-shepherd.webp.webp', alt: 'γερμανικός ποιμενικός μετά από καλλωπισμό στο Pawsh Pet Grooming' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-spitz-leyko-kourema.webp.webp', alt: 'κούρεμα σκύλου spitz στο Pawsh Γαλάτσι' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-german-shepherd-kanapes.webp.webp', alt: 'περιποίηση σκύλου german shepherd στο Pawsh' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-german-shepherd-mix.webp.webp', alt: 'german shepherd mix μετά από περιποίηση στο Pawsh Pet Grooming' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-mikros-skylos-aspro-mavro.webp.webp', alt: 'ασπρόμαυρος μικρός σκύλος μετά από grooming στο Pawsh' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-beagle-bandana.webp.webp', alt: 'beagle με μπαντάνα μετά από καλλωπισμό σκύλου στο Pawsh' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-large-mixed-dog-sofa.webp.webp', alt: 'μεγάλος σκύλος σε καναπέ μετά από περιποίηση στο Pawsh Γαλάτσι' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-german-shepherd-xalarosi.webp.webp', alt: 'χαλαρός γερμανικός ποιμενικός μετά από grooming στο Pawsh' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-black-mixed-dog.webp.webp', alt: 'μαύρος mixed σκύλος μετά από καλλωπισμό στο Pawsh Pet Grooming' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-maltese-roz-koritsaki.webp.webp', alt: 'maltese με ροζ αξεσουάρ μετά από κούρεμα σκύλου στο Pawsh' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-pitbull-blue-sofa.webp.webp', alt: 'pitbull σε μπλε καναπέ μετά από περιποίηση στο Pawsh' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-cocker-spaniel-kallopismos.webp.webp', alt: 'καλλωπισμός cocker spaniel στο Pawsh Pet Grooming Γαλάτσι' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-pomeranian-fiogkos-mavros.webp.webp', alt: 'pomeranian με μαύρο φιόγκο μετά από grooming στο Pawsh' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-megalos-skylos-kanapes-mple.webp.webp', alt: 'μεγάλος σκύλος μετά από περιποίηση σκύλου στο Pawsh' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-spitz-leyko-fiogkos.webp.webp', alt: 'λευκό spitz με φιόγκο στο Pawsh Pet Grooming' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-large-black-dog-sofa.webp.webp', alt: 'μαύρος μεγάλος σκύλος σε καναπέ μετά από καλλωπισμό στο Pawsh' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-golden-retriever-kanapes.webp.webp', alt: 'golden retriever μετά από grooming στο Pawsh Γαλάτσι' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-pomeranian-sofa.webp.webp', alt: 'περιποίηση σκύλου pomeranian στο Pawsh Pet Grooming' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-pug-blue-sofa.webp.webp', alt: 'κούρεμα σκύλου pug στο Pawsh Γαλάτσι' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-yorkshire-terrier-bowtie.webp.webp', alt: 'yorkshire terrier μετά από καλλωπισμό στο Pawsh' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-mixed-dog-colorful-bandana.webp.webp', alt: 'σκύλος με πολύχρωμη μπαντάνα μετά από περιποίηση στο Pawsh' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-megalos-skylos-kanapes-kafe.webp.webp', alt: 'μεγάλος σκύλος σε καφέ καναπέ μετά από grooming στο Pawsh' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-black-white-small-dog-bow.webp.webp', alt: 'μικρός ασπρόμαυρος σκύλος με φιόγκο στο Pawsh Pet Grooming' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-poodle-kourema-fiogkos.webp.webp', alt: 'κούρεμα poodle με φιόγκο στο Pawsh Γαλάτσι' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-poodle-kafe-kourema.webp.webp', alt: 'καφέ poodle μετά από περιποίηση σκύλου στο Pawsh' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-golden-mixed-dog.webp.webp', alt: 'golden mixed σκύλος μετά από καλλωπισμό στο Pawsh Pet Grooming' },
-    { src: 'assets/images/dogs/pet-grooming-galatsi-fluffy-brown-dog.webp.webp', alt: 'αφράτος καφέ σκύλος μετά από grooming στο Pawsh Γαλάτσι' }
+    { src: 'assets/images/pet-grooming-galatsi-poodle-kourema-fiogkos.webp', alt: 'κούρεμα σκύλου poodle στο Pawsh Γαλάτσι' },
+    { src: 'assets/images/pet-grooming-galatsi-german-shepherd-kanapes.webp', alt: 'περιποίηση σκύλου german shepherd στο Pawsh Γαλάτσι' },
+    { src: 'assets/images/pet-grooming-galatsi-pomeranian-bowtie.webp', alt: 'περιποίηση σκύλου pomeranian στο Pawsh Pet Grooming Γαλάτσι' },
+    { src: 'assets/images/pet-grooming-galatsi-husky-bandana.webp', alt: 'κούρεμα σκύλου husky στο Pawsh Γαλάτσι' },
+    { src: 'assets/images/pet-grooming-galatsi-labrador-retriever.webp', alt: 'περιποίηση σκύλου labrador retriever στο Pawsh Γαλάτσι' },
+    { src: 'assets/images/pet-grooming-galatsi-yorkshire-terrier-bowtie.webp', alt: 'κούρεμα σκύλου yorkshire terrier στο Pawsh Γαλάτσι' },
+    { src: 'assets/images/pet-grooming-galatsi-golden-retriever-kanapes.webp', alt: 'περιποίηση σκύλου golden retriever στο Pawsh Γαλάτσι' },
+    { src: 'assets/images/pet-grooming-galatsi-akita-xalarosi.webp', alt: 'περιποίηση σκύλου akita στο Pawsh Pet Grooming Γαλάτσι' }
   ];
 
   const slidesData = [];
@@ -224,6 +195,23 @@ document.addEventListener('DOMContentLoaded', () => {
   const showPreviousImage = () => {
     showImage(currentIndex - 1);
   };
+
+  const getScrollStep = () => {
+    const firstSlide = slides[0]?.slide;
+    if (!firstSlide) {
+      return scroller.clientWidth * 0.8;
+    }
+    return firstSlide.getBoundingClientRect().width + 14;
+  };
+
+  if (galleryPrevButton && galleryNextButton) {
+    galleryPrevButton.addEventListener('click', () => {
+      scroller.scrollBy({ left: -getScrollStep() * 2, behavior: 'smooth' });
+    });
+    galleryNextButton.addEventListener('click', () => {
+      scroller.scrollBy({ left: getScrollStep() * 2, behavior: 'smooth' });
+    });
+  }
 
   slides.forEach(({ slide, button }, index) => {
     button.addEventListener('click', () => openLightbox(index));

--- a/index.html
+++ b/index.html
@@ -476,13 +476,20 @@
 <h2 class="pawsh-gallery-heading">Pawsh Models</h2>
 <section id="gallery" class="pawsh-gallery-section" aria-label="Γκαλερί σκύλων">
   <div class="pawsh-gallery-container">
+    <button type="button" class="pawsh-gallery-nav pawsh-gallery-nav-prev" aria-label="Προηγούμενες φωτογραφίες">
+      <span aria-hidden="true">&#10094;</span>
+    </button>
     <div class="pawsh-gallery-scroller" aria-label="Συλλογή φωτογραφιών Pawsh" role="list">
       <div class="pawsh-gallery-track"></div>
     </div>
+    <button type="button" class="pawsh-gallery-nav pawsh-gallery-nav-next" aria-label="Επόμενες φωτογραφίες">
+      <span aria-hidden="true">&#10095;</span>
+    </button>
     <article class="pawsh-gallery-cta" aria-label="Κάλεσμα για ραντεβού">
       <p class="cta-lead">Θες και ο σκύλος σου να δείχνει έτσι;</p>
       <p>Κλείσε ραντεβού στο Pawsh Pet Grooming</p>
       <a href="https://pawshpetbeautysalon.setmore.com" class="pawsh-gallery-cta-button" target="_blank" rel="noopener">Κλείσε Ραντεβού</a>
+      <a href="gallery.html" class="pawsh-gallery-cta-button pawsh-gallery-cta-secondary">Δες όλη τη Gallery</a>
     </article>
   </div>
   <div class="pawsh-gallery-lightbox" aria-hidden="true" role="dialog" aria-modal="true" hidden>

--- a/style.css
+++ b/style.css
@@ -1069,17 +1069,26 @@ footer img.logo {
 }
 
 .pawsh-gallery-container {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.85rem;
   max-width: 1200px;
   margin: 0 auto;
 }
 
 .pawsh-gallery-scroller {
   margin: 0;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scroll-behavior: smooth;
+  scrollbar-width: thin;
 }
 
 .pawsh-gallery-track {
   display: grid;
-  grid-template-columns: repeat(1, minmax(0, 1fr));
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(180px, 1fr);
   gap: 0.85rem;
 }
 
@@ -1137,6 +1146,7 @@ footer img.logo {
 }
 
 .pawsh-gallery-cta {
+  grid-column: 1 / -1;
   margin: 1.25rem auto 0;
   max-width: 520px;
   background: linear-gradient(135deg, #063d49, #0c5565);
@@ -1160,6 +1170,23 @@ footer img.logo {
   padding: 0.55rem 1.2rem;
 }
 
+.pawsh-gallery-cta-secondary {
+  background: #f3ece0;
+  color: #063d49;
+  margin-left: 0.4rem;
+}
+
+.pawsh-gallery-nav {
+  width: 42px;
+  height: 42px;
+  border: none;
+  border-radius: 999px;
+  background: #063d49;
+  color: #fff;
+  font-size: 1.35rem;
+  cursor: pointer;
+}
+
 .pawsh-gallery-lightbox {
   position: fixed;
   inset: 0;
@@ -1180,20 +1207,19 @@ footer img.logo {
 
 body.pawsh-gallery-no-scroll { overflow: hidden; }
 
-@media (min-width: 430px) {
-  .pawsh-gallery-track { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+@media (max-width: 767px) {
+  .pawsh-gallery-container { grid-template-columns: 1fr; }
+  .pawsh-gallery-nav { display: none; }
+  .pawsh-gallery-track { grid-auto-columns: minmax(72vw, 1fr); }
+  .pawsh-gallery-cta-secondary { display: block; margin: 0.6rem auto 0; width: fit-content; }
 }
 
 @media (min-width: 768px) {
-  .pawsh-gallery-track {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    grid-auto-flow: dense;
-  }
-  .pawsh-gallery-slide:nth-child(5n) { grid-row: span 2; }
+  .pawsh-gallery-track { grid-auto-columns: minmax(220px, 1fr); }
 }
 
 @media (min-width: 1200px) {
-  .pawsh-gallery-track { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  .pawsh-gallery-track { grid-auto-columns: minmax(250px, 1fr); }
 }
 
 .cookie-banner {


### PR DESCRIPTION
### Motivation
- The homepage gallery showed only alt text because the script referenced non-existent paths (`assets/images/dogs/... .webp.webp`) instead of the real files under `assets/images/`, so a small, fast teaser carousel was needed that uses the working gallery images and links to the full gallery.

### Description
- Replaced the broken homepage gallery grid with a compact horizontal preview carousel and desktop arrow controls by adding prev/next buttons to `index.html` and a short responsive layout in `style.css`.
- Fixed the homepage image list in `assets/js/main.js` to use existing files under `assets/images/*.webp` and reduced the preview to a curated set of 8 images; images created by JS use `loading` attributes (`eager` for first items, `lazy` for others).
- Wired arrow buttons to smooth horizontal scrolling, preserved native touch swipe/scroll on mobile, and reused the existing full-screen lightbox (overlay, close, prev/next, ESC and keyboard navigation) for the same selected preview images.
- Added a clear CTA button `Δες όλη τη Gallery` linking to the existing `gallery.html` page and kept alt text in Greek for SEO and accessibility; no gallery files were moved or renamed and the full gallery page was not changed.

### Testing
- Ran `rg -n "assets/images/dogs|\.webp\.webp|pawsh-gallery-nav|Δες όλη τη Gallery" index.html assets/js/main.js style.css` to confirm the broken `/dogs/` + double-extension patterns were removed and the new nav/CTA are present (passed).
- Inspected changed file regions with `nl`/`sed` to verify the inserted buttons in `index.html`, the new responsive carousel styles in `style.css`, and the corrected image array and arrow handlers in `assets/js/main.js` (passed).
- Verified the set of modified files persisted and are limited to `index.html`, `style.css`, and `assets/js/main.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f76f9e4d988320a0461d36f7ee597a)