### PR TITLE
Add lightweight vanilla JS lightbox to gallery page

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -180,6 +180,17 @@
     </section>
     <p class="gallery-cta">Θέλετε να δείτε το επόμενο αποτέλεσμα στον δικό σας σκύλο; <a href="https://pawshpetbeautysalon.setmore.com" target="_blank" rel="noopener">Κλείστε ραντεβού</a>.</p>
   </main>
+
+  <div class="gallery-lightbox" id="gallery-lightbox" aria-hidden="true" role="dialog" aria-label="Προβολή εικόνας γκαλερί">
+    <button type="button" class="gallery-lightbox__close" aria-label="Κλείσιμο">×</button>
+    <button type="button" class="gallery-lightbox__nav gallery-lightbox__prev" aria-label="Προηγούμενη εικόνα">‹</button>
+    <figure class="gallery-lightbox__figure">
+      <img src="" alt="" class="gallery-lightbox__image">
+      <figcaption class="gallery-lightbox__caption"></figcaption>
+    </figure>
+    <button type="button" class="gallery-lightbox__nav gallery-lightbox__next" aria-label="Επόμενη εικόνα">›</button>
+  </div>
+
   <footer id="contact">
     <div class="footer-column">
       <h4>Στοιχεία Επικοινωνίας</h4>
@@ -336,6 +347,92 @@
         observer.observe(compare);
       });
     }
+
+    const galleryImages = Array.from(document.querySelectorAll('.gallery-grid img'));
+    const lightbox = document.getElementById('gallery-lightbox');
+
+    if (galleryImages.length && lightbox) {
+      const lightboxImage = lightbox.querySelector('.gallery-lightbox__image');
+      const lightboxCaption = lightbox.querySelector('.gallery-lightbox__caption');
+      const closeButton = lightbox.querySelector('.gallery-lightbox__close');
+      const prevButton = lightbox.querySelector('.gallery-lightbox__prev');
+      const nextButton = lightbox.querySelector('.gallery-lightbox__next');
+      let activeIndex = -1;
+      let touchStartX = null;
+
+      const updateLightbox = (index) => {
+        const image = galleryImages[index];
+        if (!image) return;
+
+        activeIndex = index;
+        lightboxImage.src = image.currentSrc || image.src;
+        lightboxImage.alt = image.alt || 'Pawsh gallery image';
+        lightboxCaption.textContent = image.alt || 'Pawsh Pet Grooming – Gallery';
+      };
+
+      const openLightbox = (index) => {
+        updateLightbox(index);
+        lightbox.classList.add('is-open');
+        lightbox.setAttribute('aria-hidden', 'false');
+        document.body.classList.add('gallery-lightbox-open');
+      };
+
+      const closeLightbox = () => {
+        lightbox.classList.remove('is-open');
+        lightbox.setAttribute('aria-hidden', 'true');
+        document.body.classList.remove('gallery-lightbox-open');
+        activeIndex = -1;
+      };
+
+      const showNext = () => {
+        if (activeIndex < 0) return;
+        updateLightbox((activeIndex + 1) % galleryImages.length);
+      };
+
+      const showPrev = () => {
+        if (activeIndex < 0) return;
+        updateLightbox((activeIndex - 1 + galleryImages.length) % galleryImages.length);
+      };
+
+      galleryImages.forEach((image, index) => {
+        image.addEventListener('click', () => openLightbox(index));
+      });
+
+      closeButton.addEventListener('click', closeLightbox);
+      prevButton.addEventListener('click', showPrev);
+      nextButton.addEventListener('click', showNext);
+
+      lightbox.addEventListener('click', (event) => {
+        if (event.target === lightbox) closeLightbox();
+      });
+
+      document.addEventListener('keydown', (event) => {
+        if (!lightbox.classList.contains('is-open')) return;
+
+        if (event.key === 'Escape') closeLightbox();
+        if (event.key === 'ArrowRight') showNext();
+        if (event.key === 'ArrowLeft') showPrev();
+      });
+
+      lightbox.addEventListener('touchstart', (event) => {
+        if (!event.touches || !event.touches.length) return;
+        touchStartX = event.touches[0].clientX;
+      }, { passive: true });
+
+      lightbox.addEventListener('touchend', (event) => {
+        if (touchStartX === null || !event.changedTouches || !event.changedTouches.length) return;
+        const touchEndX = event.changedTouches[0].clientX;
+        const deltaX = touchEndX - touchStartX;
+
+        if (Math.abs(deltaX) > 50) {
+          if (deltaX > 0) showPrev();
+          else showNext();
+        }
+
+        touchStartX = null;
+      }, { passive: true });
+    }
+
 
   </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -1794,3 +1794,94 @@ footer a {
     justify-content: center;
   }
 }
+
+.gallery-lightbox-open {
+  overflow: hidden;
+}
+
+.gallery-grid img {
+  cursor: zoom-in;
+}
+
+.gallery-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  background: rgba(4, 14, 20, 0.9);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.gallery-lightbox.is-open {
+  display: flex;
+}
+
+.gallery-lightbox__figure {
+  margin: 0;
+  max-width: min(92vw, 1100px);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.gallery-lightbox__image {
+  max-width: 100%;
+  max-height: calc(90vh - 3rem);
+  border-radius: 12px;
+  object-fit: contain;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
+}
+
+.gallery-lightbox__caption {
+  color: #f3ede0;
+  text-align: center;
+  font-size: 0.95rem;
+}
+
+.gallery-lightbox__close,
+.gallery-lightbox__nav {
+  position: absolute;
+  border: 0;
+  background: rgba(215, 201, 169, 0.2);
+  color: #fff;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 1.8rem;
+  line-height: 1;
+  display: grid;
+  place-items: center;
+}
+
+.gallery-lightbox__close {
+  top: 1rem;
+  right: 1rem;
+}
+
+.gallery-lightbox__prev {
+  left: 1rem;
+}
+
+.gallery-lightbox__next {
+  right: 1rem;
+}
+
+@media (max-width: 640px) {
+  .gallery-lightbox__nav {
+    top: auto;
+    bottom: 1rem;
+  }
+
+  .gallery-lightbox__prev {
+    left: calc(50% - 3.4rem);
+  }
+
+  .gallery-lightbox__next {
+    right: calc(50% - 3.4rem);
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a simple, full-screen lightbox on the full gallery page so users can view images in context without changing the existing masonry/Pinterest layout.
- Deliver the feature with vanilla JavaScript only and no external libraries to keep performance and footprint minimal.
- Preserve SEO and site constraints by keeping all original images, paths, metadata and other pages unchanged.

### Description
- Inserted a lightbox container into `gallery.html` containing the overlay, close button, prev/next controls, centered image, caption and ARIA attributes.
- Implemented vanilla JavaScript inline in `gallery.html` to wire image click → open, close via `×` button, overlay click, `Escape` key, left/right arrow navigation, prev/next buttons, and simple touch-swipe support, and reuse each image's `alt` as the caption.
- Added scoped, minimal CSS to `style.css` for the overlay background, centered responsive image sizing, caption, control buttons and a `cursor: zoom-in` hint on `.gallery-grid img`.

### Testing
- Ran an automated check that extracted all `<img src>` references from `gallery.html` and verified file existence, result: `missing 0` (no broken image references).
- Verified repository status showed only `gallery.html` and `style.css` were modified.
- Attempted a `BeautifulSoup`-based check but `bs4` was not present in the environment, so a stdlib regex-based file-existence check was used instead and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f76ff4e2a083208e94cb82cd2f7f1b)