### PR TITLE
Gallery: add desktop hover overlay text and subtle image zoom

### DIFF
--- a/style.css
+++ b/style.css
@@ -1114,9 +1114,26 @@ footer img.logo {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(to top, rgba(6, 61, 73, 0.35), rgba(6, 61, 73, 0));
+  background: rgba(0, 0, 0, 0.25);
   opacity: 0;
   transition: opacity 0.3s ease;
+}
+
+.pawsh-gallery-slide-button::before {
+  content: 'Δες αποτέλεσμα';
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  opacity: 0;
+  z-index: 1;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
 }
 
 .pawsh-gallery-slide-button:focus-visible {
@@ -1136,11 +1153,13 @@ footer img.logo {
 @media (hover: hover) {
   .pawsh-gallery-slide-button:hover img,
   .pawsh-gallery-slide-button:focus-visible img {
-    transform: scale(1.06);
+    transform: scale(1.05);
   }
 
   .pawsh-gallery-slide-button:hover::after,
-  .pawsh-gallery-slide-button:focus-visible::after {
+  .pawsh-gallery-slide-button:focus-visible::after,
+  .pawsh-gallery-slide-button:hover::before,
+  .pawsh-gallery-slide-button:focus-visible::before {
     opacity: 1;
   }
 }


### PR DESCRIPTION
### Motivation
- Improve the perceived quality of the homepage gallery with a minimal, premium-feeling visual polish applied only to hover-capable (desktop) devices. 
- Keep the change strictly visual, CSS-only, and non-invasive so layout, images, lightbox, SEO, and mobile UX remain unchanged.

### Description
- Modified only `style.css` to add hover visuals for the homepage gallery while reusing existing selectors ` .pawsh-gallery-slide-button` and `.pawsh-gallery-slide img` without renaming or restructuring elements. 
- Replaced the previous gradient overlay with a subtle dark overlay `rgba(0,0,0,0.25)` on `.pawsh-gallery-slide-button::after` and added a centered pseudo-element `::before` with the text `Δες αποτέλεσμα`, white, semi-bold, and hidden by default with `opacity: 0`. 
- Scoped hover activation to `@media (hover: hover)` so the overlay and text fade in smoothly and the image receives a slight zoom (`transform: scale(1.05)`) with existing transitions. 
- No layout or overflow changes were needed because `.pawsh-gallery-slide` already has `overflow: hidden` and `border-radius`, preventing layout shifts and image distortion.

### Testing
- No automated tests were run or are required for this CSS-only visual tweak.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7714c1f8883208a52b5b663187eeb)