### PR TITLE
Separate gallery into Results and Before/After sections; unify thumbnails and extend lightbox

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -98,9 +98,12 @@
   </div>
 
   <main class="py-8">
-    <h1 class="text-center text-3xl md:text-4xl font-semibold tracking-wide text-[#063d49] mb-8">Γκαλερί – Πριν / Μετά</h1>
-    <p class="gallery-intro">Δείτε στιγμές από πραγματικά grooming ραντεβού στο Pawsh Pet Beauty Salon και την προσεγμένη δουλειά που γίνεται με ηρεμία, λεπτομέρεια και σεβασμό σε κάθε σκύλο.</p>
-    <section class="gallery-grid" aria-label="Gallery σκύλων μετά τον καλλωπισμό">
+    <h1 class="text-center text-3xl md:text-4xl font-semibold tracking-wide text-[#063d49] mb-8">Gallery Pawsh – Καλλωπισμός &amp; Μεταμορφώσεις</h1>
+
+    <section class="gallery-page-section" aria-labelledby="gallery-results-title">
+      <h2 id="gallery-results-title" class="gallery-section-title">Gallery Αποτελεσμάτων</h2>
+      <p class="gallery-intro">Δες στιγμές από περιποιήσεις σκύλων στο Pawsh Pet Grooming.</p>
+      <div class="gallery-grid" aria-label="Gallery σκύλων μετά τον καλλωπισμό">
       <img src="./assets/images/pet-grooming-galatsi-poodle-kourema-fiogkos.webp" alt="Καλλωπισμός poodle στο Γαλάτσι με φιόγκο – επαγγελματικό pet grooming Pawsh" loading="eager" decoding="async" fetchpriority="high">
       <img src="./assets/images/pet-grooming-galatsi-german-shepherd-kanapes.webp" alt="Γερμανικός ποιμενικός μετά από grooming σε καναπέ στο Γαλάτσι" loading="eager" decoding="async">
       <img src="./assets/images/pet-grooming-galatsi-pomeranian-bowtie.webp" alt="Pomeranian με παπιγιόν μετά από καλλωπισμό στο Pawsh Γαλάτσι" loading="lazy" decoding="async">
@@ -138,9 +141,13 @@
       <img src="./assets/images/pet-grooming-galatsi-pomeranian-fiogkos-mavros.webp" alt="Pomeranian με μαύρο φιόγκο μετά από pet grooming στο Pawsh στο Γαλάτσι" loading="lazy" decoding="async">
       <img src="./assets/images/pet-grooming-galatsi-fluffy-brown-dog.webp" alt="Χνουδωτός καφέ σκύλος μετά από grooming στο Γαλάτσι" loading="lazy" decoding="async">
       <img src="./assets/images/pet-grooming-galatsi-mikros-skylos-aspro-mavro.webp" alt="Μικρό ασπρόμαυρο σκυλάκι μετά από καλλωπισμό στο Pawsh Γαλάτσι" loading="lazy" decoding="async">
+      </div>
     </section>
 
-    <section class="pawsh-compare-grid" aria-label="Σύγκριση φωτογραφιών πριν και μετά">
+    <section class="gallery-page-section" aria-labelledby="gallery-before-after-title">
+      <h2 id="gallery-before-after-title" class="gallery-section-title">Πριν &amp; Μετά</h2>
+      <p class="gallery-intro">Σύγκρινε το αποτέλεσμα πριν και μετά την περιποίηση.</p>
+      <div class="pawsh-compare-grid" aria-label="Σύγκριση φωτογραφιών πριν και μετά">
       <div class="pawsh-compare">
         <img class="pc-after" src="before&amp;after/1*.jpg" alt="Σκύλος 1 μετά τον καλλωπισμό στο Pawsh Pet Beauty Salon" loading="lazy">
         <img class="pc-before" src="before&amp;after/1.jpg" alt="Σκύλος 1 πριν τον καλλωπισμό στο Pawsh Pet Beauty Salon" loading="lazy">
@@ -176,6 +183,7 @@
         <img class="pc-before" src="before&amp;after/6.jpg" alt="Σκύλος 6 πριν τον καλλωπισμό στο Pawsh Pet Beauty Salon" loading="lazy">
         <input type="range" class="pc-slider" min="0" max="100" value="50" aria-label="Σύγκριση πριν και μετά – Καλλωπισμός 6">
         <div class="pc-handle"><span></span></div>
+      </div>
       </div>
     </section>
     <p class="gallery-cta">Θέλετε να δείτε το επόμενο αποτέλεσμα στον δικό σας σκύλο; <a href="https://pawshpetbeautysalon.setmore.com" target="_blank" rel="noopener">Κλείστε ραντεβού</a>.</p>
@@ -348,7 +356,7 @@
       });
     }
 
-    const galleryImages = Array.from(document.querySelectorAll('.gallery-grid img'));
+    const galleryImages = Array.from(document.querySelectorAll('.gallery-grid img, .pawsh-compare img'));
     const lightbox = document.getElementById('gallery-lightbox');
 
     if (galleryImages.length && lightbox) {

--- a/style.css
+++ b/style.css
@@ -741,25 +741,19 @@ footer img.logo {
 
 /* Paw background boxes for gallery */
 .pawsh-compare-grid {
-  max-width: min(1100px, 92vw);
-  margin: 3rem auto 0;
-  padding: 0 1rem 3rem;
   display: grid;
-  gap: 2rem;
-  grid-template-columns: 1fr;
-}
-
-@media (min-width: 768px) {
-  .pawsh-compare-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 18px;
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 0 1rem;
 }
 
 .pawsh-compare {
   position: relative;
   overflow: hidden;
-  border-radius: 18px;
-  box-shadow: 0 24px 48px rgba(6, 61, 73, 0.2);
+  border-radius: 16px;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.10);
   background: #0f2d34;
   aspect-ratio: 4 / 5;
   isolation: isolate;
@@ -851,8 +845,14 @@ footer img.logo {
 }
 
 @media (max-width: 640px) {
+  .pawsh-compare-grid {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
   .pawsh-compare {
     aspect-ratio: 3 / 4;
+    border-radius: 14px;
   }
 }
 
@@ -862,6 +862,20 @@ footer img.logo {
   transition: transform 0.3s ease;
   overflow: hidden;
   aspect-ratio: 1 / 1;
+}
+
+
+.gallery-page-section {
+  margin-bottom: 2.5rem;
+}
+
+.gallery-section-title {
+  max-width: 1180px;
+  margin: 0 auto 0.5rem;
+  padding: 0 1rem;
+  color: #063d49;
+  font-size: clamp(1.5rem, 2vw, 2rem);
+  font-weight: 700;
 }
 
 /* Gallery page base styles */


### PR DESCRIPTION
### Motivation
- Improve clarity of the full gallery page by separating regular result photos from the interactive before/after comparisons. 
- Make before/after thumbnails visually consistent with the main gallery and ensure the existing lightbox works for both sections.

### Description
- Replaced the single page heading with `Gallery Pawsh – Καλλωπισμός & Μεταμορφώσεις` and wrapped content into two semantic sections: `Gallery Αποτελεσμάτων` and `Πριν & Μετά` using `.gallery-page-section` and H2 IDs `gallery-results-title` / `gallery-before-after-title`.
- Kept all original image files and paths and moved the existing `.gallery-grid` and `.pawsh-compare-grid` blocks into the new section wrappers without removing images.
- Unified before/after thumbnails to match gallery cards by updating CSS for `.pawsh-compare-grid` (grid sizing, gap, max-width, padding) and `.pawsh-compare` (border-radius, shadow, responsive radius) and added `.gallery-section-title` and `.gallery-page-section` for spacing and heading styling.
- Ensured lightbox includes both areas by changing the JS selector to `document.querySelectorAll('.gallery-grid img, .pawsh-compare img')` so clicks on images from either section open the same lightbox.

### Testing
- Verified markup and counts with command-line checks and `rg`/`sed` inspections (file structure and new headings present) which succeeded.
- Confirmed `h1` appears once and the two `h2` section headings are present by scanning `gallery.html`, which returned the expected single `h1` and the two new `h2` entries.
- Ran `git status` / `git diff` and committed the changes successfully with message indicating the update, which succeeded.
- Noted an environment warning when attempting a `bs4` (BeautifulSoup) check because the `bs4` package is not installed; this is non-blocking because checks were performed with `rg`/`sed` instead.

Modified files: `gallery.html`, `style.css`.
Exact selectors/classes changed or used: `.gallery-page-section`, `.gallery-section-title`, `.gallery-grid`, `.pawsh-compare-grid`, `.pawsh-compare`, and the lightbox selector `'.gallery-grid img, .pawsh-compare img'`.
Index file check: `index.html` was not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f77594e1588320986757fba71fdd23)