### PR TITLE
Style gallery CTA as a premium outlined button

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -186,7 +186,7 @@
       </div>
       </div>
     </section>
-    <p class="gallery-cta">Θέλετε να δείτε το επόμενο αποτέλεσμα στον δικό σας σκύλο; <a href="https://pawshpetbeautysalon.setmore.com" target="_blank" rel="noopener">Κλείστε ραντεβού</a>.</p>
+    <p class="gallery-cta">Θέλετε να δείτε το επόμενο αποτέλεσμα στον δικό σας σκύλο; <a href="https://pawshpetbeautysalon.setmore.com" target="_blank" rel="noopener" class="gallery-cta-button">Κλείστε ραντεβού</a>.</p>
   </main>
 
   <div class="gallery-lightbox" id="gallery-lightbox" aria-hidden="true" role="dialog" aria-label="Προβολή εικόνας γκαλερί">

--- a/style.css
+++ b/style.css
@@ -1466,6 +1466,26 @@ body.pawsh-gallery-no-scroll { overflow: hidden; }
   font-weight: 600;
 }
 
+.gallery-cta-button {
+  display: inline-block;
+  margin-top: 12px;
+  padding: 10px 18px;
+  border: 2px solid var(--main-bg);
+  color: var(--main-bg);
+  text-decoration: none;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: all 0.25s ease;
+}
+
+@media (hover: hover) {
+  .gallery-cta-button:hover {
+    background-color: var(--main-bg);
+    color: #1f2f2f;
+  }
+}
+
 .map-link {
   display: inline-block;
   margin: 0 0 1rem;


### PR DESCRIPTION
### Motivation
- The gallery bottom CTA looked like plain text and needed a subtle, premium visual treatment to increase prominence without changing layout. 
- The goal was to convert the existing “Κλείστε ραντεβού” link into an outlined pill button that reads well on desktop and mobile. 
- Changes must be limited to the CTA markup and `style.css` styling only, preserving gallery layout and behavior.

### Description
- Added `class="gallery-cta-button"` to the anchor that contains “Κλείστε ραντεβού” in `gallery.html` so the element can be targeted without altering structure. 
- Added scoped CSS in `style.css` for `.gallery-cta-button` to render a minimal outlined pill button using `var(--main-bg)` for the border and text and a hover inversion inside `@media (hover: hover)`. 
- No layout, lightbox logic, SEO metadata, or unrelated files were modified; edits were limited to `gallery.html` and `style.css` only.

### Testing
- Ran text searches and verifications with `rg -n "Θέλετε να δείτε|Κλείστε ραντεβού" gallery.html` and `rg -n "gallery-cta|cta" style.css gallery.html`, which located the updated anchor and styles successfully. 
- Inspected the diff with `git diff -- gallery.html style.css` and committed the change with `git commit -m "Style gallery CTA as premium outlined button"`, both of which completed successfully. 
- Verified hover behavior is scoped to hover-capable devices via `@media (hover: hover)` and confirmed no other button styles were affected by the scoped selector.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7786511988320ba125d8b9ab67087)