### PR TITLE
Gallery: 4-column desktop and 2-column mobile grid

### DIFF
--- a/style.css
+++ b/style.css
@@ -1410,9 +1410,9 @@ body.pawsh-gallery-no-scroll { overflow: hidden; }
 
  .gallery-paw-bg .gallery-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 18px;
-  max-width: 1180px;
+  max-width: 1280px;
   margin: 0 auto;
   padding: 0 1rem;
 }
@@ -1437,7 +1437,7 @@ body.pawsh-gallery-no-scroll { overflow: hidden; }
 @media (max-width: 640px) {
   .gallery-paw-bg .gallery-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 16px;
+    gap: 12px;
   }
 
   .gallery-paw-bg .gallery-grid img {
@@ -1445,7 +1445,7 @@ body.pawsh-gallery-no-scroll { overflow: hidden; }
   }
 }
 
-@media (max-width: 480px) {
+@media (max-width: 360px) {
   .gallery-paw-bg .gallery-grid {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
### Motivation
- Desktop gallery images were too large and typically produced about 3 columns instead of fitting 4 where space allows. 
- Many mobile devices collapsed to a single column because the single-column breakpoint was at 480px. 
- Changes must be confined to the gallery styles and must not affect the homepage or carousel.

### Description
- Updated `.gallery-paw-bg .gallery-grid` `grid-template-columns` from `repeat(auto-fit, minmax(240px, 1fr))` to `repeat(auto-fit, minmax(200px, 1fr))` to allow up to 4 images per row on wider viewports. 
- Increased the gallery container `max-width` from `1180px` to `1280px` to give the grid a bit more horizontal room on large screens. 
- Reduced the mobile grid `gap` from `16px` to `12px` for a tighter two-column layout and kept `@media (max-width: 640px)` as the 2-column breakpoint with `grid-template-columns: repeat(2, minmax(0, 1fr))`. 
- Moved the single-column fallback from `@media (max-width: 480px)` to `@media (max-width: 360px)` so only very small screens collapse to 1 column; all edits are confined to `style.css` and target only `.gallery-paw-bg .gallery-grid` rules.

### Testing
- Located and inspected the gallery rules with code search and file excerpts and confirmed the new `minmax(200px, 1fr)` and `max-width: 1280px` values are present. 
- Compared the stylesheet diff and verified that only `style.css` was changed and that the changes are limited to the gallery grid rules. 
- Confirmed `@media (max-width: 640px)` now enforces two columns and `@media (max-width: 360px)` enforces a single column as intended. 
- Verified homepage files including `index.html` and carousel-related assets were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f779b3adf48320996d8f8bcce36adb)