### PR TITLE
Enforce 2-column mobile layout for gallery (.gallery-paw-bg .gallery-grid)

### DIFF
--- a/style.css
+++ b/style.css
@@ -1436,7 +1436,8 @@ body.pawsh-gallery-no-scroll { overflow: hidden; }
 
 @media (max-width: 640px) {
   .gallery-paw-bg .gallery-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
     gap: 12px;
   }
 
@@ -1447,7 +1448,7 @@ body.pawsh-gallery-no-scroll { overflow: hidden; }
 
 @media (max-width: 360px) {
   .gallery-paw-bg .gallery-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr !important;
   }
 }
 


### PR DESCRIPTION
### Motivation
- The gallery was rendering as a single column on many mobile devices due to cascade/specificity overrides, so the gallery grid must be hardened without affecting other pages. 
- The intent is to keep 2 columns on normal mobile widths and fall back to 1 column only under ~360px, scoped to the gallery container selector.

### Description
- Modified only `style.css` to scope the fix to `.gallery-paw-bg .gallery-grid` and preserve desktop layout. 
- Added `display: grid;` inside the `@media (max-width: 640px)` rule and enforced `grid-template-columns: repeat(2, minmax(0, 1fr)) !important;` to prevent mobile overrides from collapsing the grid. 
- Added `grid-template-columns: 1fr !important;` under `@media (max-width: 360px)` so a single column is used only on very small screens. 
- Conflicting CSS: no global `.gallery-grid` layout rule was found in `style.css`, so the fix uses scoped selectors and `!important` to overcome cascade/specificity issues; final selector in use is `.gallery-paw-bg .gallery-grid` with media-query overrides. 

### Testing
- Located occurrences and potential overrides with `rg` and inspected the gallery rule block with `sed` and `nl`, confirming the change location. 
- Applied the patch and verified the file diff to ensure only `style.css` was changed. 
- Verified the final CSS block now includes `display: grid` at `<=640px`, `grid-template-columns: repeat(2, minmax(0, 1fr)) !important` at `<=640px`, and `grid-template-columns: 1fr !important` at `<=360px`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f77c11d2608320a59b03436e673b01)