### PR TITLE
Make gallery “Κλείστε ραντεβού” CTA visible as outlined button

### DIFF
--- a/style.css
+++ b/style.css
@@ -1468,21 +1468,31 @@ body.pawsh-gallery-no-scroll { overflow: hidden; }
 
 .gallery-cta-button {
   display: inline-block;
+  margin-left: 10px;
   margin-top: 12px;
-  padding: 10px 18px;
-  border: 2px solid var(--main-bg);
-  color: var(--main-bg);
+  padding: 10px 20px;
+  border: 2px solid #064851;
+  color: #064851;
+  background: transparent;
   text-decoration: none;
   border-radius: 999px;
-  font-weight: 600;
+  font-weight: 700;
   font-size: 0.95rem;
-  transition: all 0.25s ease;
+  line-height: 1;
+  vertical-align: middle;
+  transition: background-color 0.25s ease, color 0.25s ease, transform 0.25s ease;
+}
+
+.gallery-cta-button:visited {
+  color: #064851;
 }
 
 @media (hover: hover) {
-  .gallery-cta-button:hover {
-    background-color: var(--main-bg);
-    color: #1f2f2f;
+  .gallery-cta-button:hover,
+  .gallery-cta-button:focus-visible {
+    background-color: #064851;
+    color: #d7c9a9;
+    transform: translateY(-1px);
   }
 }
 


### PR DESCRIPTION
### Motivation
- The bottom gallery CTA blended into the beige background in its normal state, so make it clearly visible while preserving the premium minimal style and without changing layout or other pages.

### Description
- Replaced the `.gallery-cta-button` rules in `style.css` to use an outlined teal appearance (`#064851`) with improved spacing, stronger weight, explicit transparent background, and refined transitions, and added a `:visited` rule plus `:focus-visible` for accessible focus/hover behavior; only `style.css` was modified.

.gallery-cta-button {
  display: inline-block;
  margin-left: 10px;
  margin-top: 12px;
  padding: 10px 20px;
  border: 2px solid #064851;
  color: #064851;
  background: transparent;
  text-decoration: none;
  border-radius: 999px;
  font-weight: 700;
  font-size: 0.95rem;
  line-height: 1;
  vertical-align: middle;
  transition: background-color 0.25s ease, color 0.25s ease, transform 0.25s ease;
}

.gallery-cta-button:visited {
  color: #064851;
}

@media (hover: hover) {
  .gallery-cta-button:hover,
  .gallery-cta-button:focus-visible {
    background-color: #064851;
    color: #d7c9a9;
    transform: translateY(-1px);
  }
}

**Confirmation:** only CTA styling in `style.css` was changed; no layout, images, lightbox, header/footer, SEO, or homepage files were modified.

### Testing
- Ran `rg -n "gallery-cta-button|gallery cta|Κλείστε" style.css gallery.html` to locate the selector and CTA usage, and it returned the expected entries.
- Inspected the updated block with `nl -ba style.css | sed -n '1469,1497p'` and reviewed the `git diff -- style.css` to confirm the new CSS and that only `style.css` was modified.
- All automated checks executed above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f77e12f75883208c30720bd92b1184)