### PR TITLE
Refine gallery bottom CTA layout and visibility

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -186,7 +186,10 @@
       </div>
       </div>
     </section>
-    <p class="gallery-cta">Θέλετε να δείτε το επόμενο αποτέλεσμα στον δικό σας σκύλο; <a href="https://pawshpetbeautysalon.setmore.com" target="_blank" rel="noopener" class="gallery-cta-button">Κλείστε ραντεβού</a>.</p>
+    <div class="gallery-bottom-cta">
+      <p>Θέλετε να δείτε το επόμενο αποτέλεσμα στον δικό σας σκύλο;</p>
+      <a href="https://pawshpetbeautysalon.setmore.com" target="_blank" rel="noopener" class="gallery-cta-button">Κλείστε ραντεβού</a>
+    </div>
   </main>
 
   <div class="gallery-lightbox" id="gallery-lightbox" aria-hidden="true" role="dialog" aria-label="Προβολή εικόνας γκαλερί">

--- a/style.css
+++ b/style.css
@@ -1452,8 +1452,7 @@ body.pawsh-gallery-no-scroll { overflow: hidden; }
   }
 }
 
-.gallery-intro,
-.gallery-cta {
+.gallery-intro {
   max-width: 760px;
   margin: 0 auto 2rem;
   padding: 0 1rem;
@@ -1461,39 +1460,62 @@ body.pawsh-gallery-no-scroll { overflow: hidden; }
   color: var(--secondary);
 }
 
-.gallery-cta {
-  margin-top: 2rem;
-  margin-bottom: 0;
-  font-weight: 600;
+.gallery-bottom-cta {
+  text-align: center;
+  margin: 3rem auto 2rem;
+  padding: 0 1rem;
 }
 
-.gallery-cta-button {
-  display: inline-block;
-  margin-left: 10px;
-  margin-top: 12px;
-  padding: 10px 20px;
+.gallery-bottom-cta p {
+  margin: 0 0 1rem;
+  color: #3f3f3f;
+  font-weight: 700;
+  line-height: 1.5;
+}
+
+.gallery-cta-button,
+.gallery-cta-button:visited {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 11px 22px;
   border: 2px solid #064851;
-  color: #064851;
-  background: transparent;
+  background-color: #064851;
+  color: #d7c9a9;
   text-decoration: none;
   border-radius: 999px;
   font-weight: 700;
   font-size: 0.95rem;
   line-height: 1;
-  vertical-align: middle;
   transition: background-color 0.25s ease, color 0.25s ease, transform 0.25s ease;
 }
 
-.gallery-cta-button:visited {
-  color: #064851;
+.gallery-cta-button:focus-visible {
+  outline: 3px solid rgba(6, 72, 81, 0.35);
+  outline-offset: 3px;
 }
 
 @media (hover: hover) {
-  .gallery-cta-button:hover,
-  .gallery-cta-button:focus-visible {
-    background-color: #064851;
-    color: #d7c9a9;
+  .gallery-cta-button:hover {
+    background-color: transparent;
+    color: #064851;
     transform: translateY(-1px);
+  }
+}
+
+@media (max-width: 640px) {
+  .gallery-bottom-cta {
+    margin: 2.5rem auto 1.5rem;
+  }
+
+  .gallery-bottom-cta p {
+    font-size: 0.98rem;
+  }
+
+  .gallery-cta-button,
+  .gallery-cta-button:visited {
+    width: min(100%, 260px);
   }
 }
 


### PR DESCRIPTION
### Motivation
- The existing bottom CTA in `gallery.html` rendered inline and produced awkward punctuation/spacing on desktop and poor visibility on mobile. 
- The intent is to present a clear, accessible call-to-action block that reads well on all viewports without requiring hover.

### Description
- Replaced the inline CTA paragraph in `gallery.html` with a centered block `<div class="gallery-bottom-cta">` containing a single `<p>` line and a separate `<a class="gallery-cta-button">` button, preserving the original booking `href` exactly. 
- Replaced the previous `.gallery-cta`/inline button styles by adding `.gallery-bottom-cta` and overriding `.gallery-cta-button` so the button is filled and fully readable in its normal state on desktop and mobile. 
- Removed the trailing punctuation that previously followed the link so no stray punctuation appears after the button. 
- Kept changes limited to `gallery.html` and `style.css` only, without touching gallery grid, before/after components, lightbox JS, header/footer, homepage, SEO, or image paths.

### Testing
- Ran class/usage checks with `rg -n "gallery-bottom-cta|gallery-cta\b|gallery-cta-button" gallery.html style.css` and confirmed the new selectors are present; command succeeded. 
- Verified the updated markup lines with `nl -ba gallery.html | sed -n '182,198p'` and the new CSS block with `nl -ba style.css | sed -n '1450,1525p'`; both outputs show the intended changes and succeeded. 
- Committed the change and confirmed the commit contains only `gallery.html` and `style.css` with `git show --name-only --oneline -1`; command succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7808aa4588320b8dacbee3be434da)