### PR TITLE
Add subtle alternating section backgrounds to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
   <meta property="og:url" content="https://www.pawsh.gr/">
   <meta property="og:locale" content="el_GR">
 </head>
-  <body>
+  <body class="home-page">
     <h2 class="sr-only">Καλλωπισμός Σκύλων στο Γαλάτσι με Ασφάλεια, Αγάπη & Θετική Προσέγγιση</h2>
     <p class="sr-only">Στο Pawsh Pet Beauty Salon προσφέρουμε επαγγελματικές υπηρεσίες pet grooming, κομμωτηρίου σκύλων και καλλωπισμού σκύλων στο Γαλάτσι. Εξυπηρετούμε κηδεμόνες από Γαλάτσι, Κυψέλη, Πατήσια, Ψυχικό και Φιλοθέη, με στόχο τη χαρά και την ευεξία κάθε κατοικιδίου.</p>
     <header class="bg-[#063d49] text-white">
@@ -399,7 +399,7 @@
     }
   </script>
 
-  <section id="philosophy" class="philosophy">
+  <section id="philosophy" class="section philosophy">
     <div class="philosophy-content">
       <div class="philosophy-text">
         <h2 class="font-bold">Η Φιλοσοφία μας</h2>
@@ -417,7 +417,7 @@
     </div>
   </section>
 
-    <section id="services" class="services">
+    <section id="services" class="section services alt">
       <h2>Οι Υπηρεσίες μας</h2>
       <p class="services-intro">Επιλέξτε την υπηρεσία που ταιριάζει στον σκύλο σας και κλείστε εύκολα ραντεβού. Για πλήρη ανάλυση δείτε τη σελίδα <a href="services.html">Υπηρεσίες</a> ή το <a href="grooming-galatsi.html">κομμωτήριο σκύλων στο Γαλάτσι</a>.</p>
       <div class="services-grid">
@@ -460,7 +460,7 @@
       <a href="https://pawshpetbeautysalon.setmore.com" class="hero-cta" target="_blank" rel="noopener">Κλείσε Ραντεβού</a>
     </section>
 
-  <section class="areas-served" aria-labelledby="areas-served-title">
+  <section class="section areas-served" aria-labelledby="areas-served-title">
     <h2 id="areas-served-title">Περιοχές που εξυπηρετούμε</h2>
     <p>Υποδεχόμαστε καθημερινά κηδεμόνες που αναζητούν ποιοτικό καλλωπισμό σκύλων στο Γαλάτσι και σε κοντινές περιοχές, πάντα με την ίδια προσοχή στη λεπτομέρεια και τη φροντίδα. Μάθετε περισσότερα στη dedicated σελίδα μας για <a href="grooming-galatsi.html">pet grooming στο Γαλάτσι</a>.</p>
     <ul class="areas-served-list">
@@ -473,7 +473,7 @@
   </section>
 
 <h2 class="pawsh-gallery-heading">Pawsh Models</h2>
-<section id="gallery" class="pawsh-gallery-section" aria-label="Γκαλερί σκύλων">
+<section id="gallery" class="section pawsh-gallery-section alt" aria-label="Γκαλερί σκύλων">
   <div class="pawsh-gallery-container">
     <button type="button" class="pawsh-gallery-nav pawsh-gallery-nav-prev" aria-label="Προηγούμενες φωτογραφίες">
       <span aria-hidden="true">&#10094;</span>
@@ -507,7 +507,7 @@
 </section>
 
 
-  <section class="faq">
+  <section class="section faq">
     <h2>Συχνές Ερωτήσεις</h2>
     <div class="faq-item">
       <div class="faq-question">Πόσο κοστίζει ένα grooming;</div>
@@ -547,7 +547,7 @@
     </div>
     </section>
   
-<section id="reviews" class="reviews">
+<section id="reviews" class="section reviews alt">
   <h2>Κριτικές Πελατών</h2>
   <p class="reviews-intro">Οι εμπειρίες των πελατών μας επιβεβαιώνουν την ήρεμη, προσεγμένη και premium φροντίδα που θέλουμε να προσφέρουμε σε κάθε επίσκεψη.</p>
   <a href="https://www.google.com/maps/search/?api=1&query=Pawsh%20Pet%20Beauty%20Salon%2C%20Agias%20Glykerias%2062%2C%20Galatsi" class="reviews-inline-cta" target="_blank" rel="noopener">Δες όλες τις αξιολογήσεις στο Google</a>
@@ -616,7 +616,7 @@
     </div>
   </section>
 
-<section class="reviews-thankyou" aria-label="100+ αξιολογήσεις στο Google">
+<section class="section reviews-thankyou" aria-label="100+ αξιολογήσεις στο Google">
   <div class="reviews-thankyou__inner">
     <h3>100+ αξιολογήσεις στο Google</h3>
     <p>Σας ευχαριστούμε για την εμπιστοσύνη! Το Pawsh Pet Beauty Salon ξεπέρασε τις 100 αξιολογήσεις στο Google με βαθμολογία 5.0. Η αγάπη και η στήριξή σας μάς δίνουν δύναμη να προσφέρουμε καθημερινά προσεγμένη, ήρεμη και επαγγελματική φροντίδα σε κάθε κατοικίδιο.</p>
@@ -632,7 +632,7 @@
   </div>
 </section>
 
-    <section class="map">
+    <section class="section map alt">
       <a class="map-link" href="https://www.google.com/maps/search/?api=1&query=%CE%91%CE%B3%CE%AF%CE%B1%CF%82+%CE%93%CE%BB%CF%85%CE%BA%CE%B5%CF%81%CE%AF%CE%B1%CF%82+62%2C+%CE%93%CE%B1%CE%BB%CE%AC%CF%84%CF%83%CE%B9+111+47%2C+%CE%95%CE%BB%CE%BB%CE%AC%CE%B4%CE%B1" target="_blank" rel="noopener">Άνοιξε τη διεύθυνση στο Google Maps</a>
       <iframe src="https://www.google.com/maps?q=Αγίας+Γλυκερίας+62,+Γαλάτσι,+111+47,+Ελλάδα&output=embed" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
     </section>

--- a/style.css
+++ b/style.css
@@ -219,6 +219,15 @@ header nav a {
   }
 }
 
+
+.home-page .section {
+  background-color: #d7c9a9;
+}
+
+.home-page .section.alt {
+  background-color: #efe6d3;
+}
+
 section {
   padding: 4rem 1rem;
   max-width: 960px;


### PR DESCRIPTION
### Motivation
- Improve visual flow and readability on the homepage by introducing subtle, premium-aligned background alternation between sections while preserving existing layout, content and functionality. 

### Description
- Scoped the change to the homepage by adding `class="home-page"` to the `<body>` in `index.html` and adding a shared `section` class to main homepage sections without altering content or structure. 
- Added two CSS rules in `style.css`: `.home-page .section { background-color: #d7c9a9; }` and `.home-page .section.alt { background-color: #efe6d3; }` to provide subtle alternating backgrounds. 
- Manually applied alternation in `index.html` so the hero kept its existing styles and was not changed. 
- No changes were made to SEO metadata, JSON-LD schema, sitemap, robots, gallery JS, header/footer, images, copy, or section order. 

### Testing
- Ran repository/file discovery and inspections with `rg --files` and `sed`/`nl` snippets to verify the right files were updated and class placements were correct, and those checks succeeded. 
- Verified the diff with `git diff -- index.html style.css` and inspected working tree with `git status --short` to confirm only `index.html` and `style.css` were modified, and these checks succeeded. 
- Note: no automated visual browser tests were run in this CLI session; visual verification on desktop and mobile is recommended to confirm perceived contrast and gallery appearance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f784d555d48320b30b894da372ae00)