### PR TITLE
Integrate "Pawsh Models" heading into gallery section and make background full-width

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,9 +472,9 @@
     </ul>
   </section>
 
-<h2 class="pawsh-gallery-heading">Pawsh Models</h2>
 <section id="gallery" class="section pawsh-gallery-section alt" aria-label="Γκαλερί σκύλων">
   <div class="pawsh-gallery-container">
+    <h2 class="pawsh-gallery-heading">Pawsh Models</h2>
     <button type="button" class="pawsh-gallery-nav pawsh-gallery-nav-prev" aria-label="Προηγούμενες φωτογραφίες">
       <span aria-hidden="true">&#10094;</span>
     </button>

--- a/style.css
+++ b/style.css
@@ -1083,12 +1083,16 @@ footer img.logo {
   font-size: clamp(2rem, 5vw, 2.75rem);
   color: #063d49;
   font-weight: 700;
-  margin: 4rem auto 1.25rem;
+  margin: 0 auto 1.25rem;
   padding: 0 1rem;
+  grid-column: 1 / -1;
 }
 
 .pawsh-gallery-section {
-  padding: 2.5rem 1rem 3rem;
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  padding: 2.5rem 0 3rem;
 }
 
 .pawsh-gallery-container {
@@ -1098,6 +1102,7 @@ footer img.logo {
   gap: 0.85rem;
   max-width: 1200px;
   margin: 0 auto;
+  padding: 0 1rem;
 }
 
 .pawsh-gallery-scroller {


### PR DESCRIPTION
### Motivation
- The gallery title was visually detached from the gallery block because the `<h2 class="pawsh-gallery-heading">Pawsh Models</h2>` lived outside the gallery `<section>`, breaking the section background continuity.
- The intent is to make the gallery a single cohesive block with the title, carousel, and CTA sharing the same background on all screen sizes.
- The fix must apply globally without excluding mobile and must not change gallery logic or other files.

### Description
- Moved the `Pawsh Models` heading inside the gallery structure so the `<h2 class="pawsh-gallery-heading">` is now the first child of `#gallery > .pawsh-gallery-container` in `index.html`.
- Updated CSS so the outer section owns the background and spans the full width by changing `.pawsh-gallery-section` to `width: 100%; max-width: none; margin: 0; padding: 2.5rem 0 3rem;` in `style.css`.
- Kept content centered by preserving `.pawsh-gallery-container { max-width: 1200px; margin: 0 auto; }` and added `padding: 0 1rem;` while adjusting `.pawsh-gallery-heading` to `margin: 0 auto 1.25rem; grid-column: 1 / -1;` so the title stays integrated with the gallery grid across breakpoints.

### Testing
- Verified the presence and placement of the title and gallery selectors with `rg -n "Pawsh Models|gallery|pawsh-gallery" index.html style.css`, which reported the updated locations.
- Inspected the modified file fragments with `sed -n`/`nl -ba` to confirm the `<h2>` is inside `#gallery` and the CSS blocks were updated as intended.
- Confirmed no JS or restricted files were changed and that carousel/lightbox logic was left untouched by only editing `index.html` and `style.css`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f78aa8a8b88320853dc66d35f5e1e5)