### PR TITLE
Make homepage sections full-width and align EN homepage with GR (restore reviews visual)

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -372,7 +372,7 @@
     }
   </script>
 
-  <section id="philosophy" class="philosophy">
+  <section id="philosophy" class="section philosophy">
     <div class="philosophy-content">
       <div class="philosophy-text">
         <h2 class="font-bold">Our Philosophy</h2>
@@ -391,7 +391,7 @@
     </div>
   </section>
 
-    <section id="services" class="services">
+    <section id="services" class="section services alt">
       <h2>Our Services</h2>
       <p class="services-intro">Professional grooming services tailored to your dog’s needs. Visit our <a href="services.html">Services</a> page for a full breakdown, or explore <a href="grooming-galatsi.html">dog grooming in Galatsi</a> for local information.</p>
       <div class="services-grid">
@@ -434,7 +434,7 @@
       <a href="https://pawshpetbeautysalon.setmore.com" class="hero-cta" target="_blank" rel="noopener">Book Appointment</a>
     </section>
 
-  <section class="areas-served" aria-labelledby="areas-served-title">
+  <section class="section areas-served" aria-labelledby="areas-served-title">
     <h2 id="areas-served-title">Areas We Serve</h2>
     <p>We regularly welcome dog parents from Galatsi and nearby neighbourhoods who are looking for premium, dependable grooming. Learn more on our dedicated page about <a href="grooming-galatsi.html">dog grooming in Galatsi</a>.</p>
     <ul class="areas-served-list">
@@ -446,9 +446,9 @@
     </ul>
   </section>
 
-<h2 class="pawsh-gallery-heading">Pawsh Models</h2>
 <section id="gallery" class="section pawsh-gallery-section alt" aria-label="Dog gallery" data-gallery-path-prefix="..">
   <div class="pawsh-gallery-container">
+    <h2 class="pawsh-gallery-heading">Pawsh Models</h2>
     <button type="button" class="pawsh-gallery-nav pawsh-gallery-nav-prev" aria-label="Previous photos">
       <span aria-hidden="true">&#10094;</span>
     </button>
@@ -481,7 +481,7 @@
 </section>
 
 
-  <section class="faq">
+  <section class="section faq">
     <h2>Frequently Asked Questions</h2>
     <div class="faq-item">
       <div class="faq-question">How much does grooming cost?</div>
@@ -521,7 +521,7 @@
     </div>
     </section>
   
-<section id="reviews" class="reviews">
+<section id="reviews" class="section reviews alt">
   <h2>Client Reviews</h2>
   <p class="reviews-intro">Our clients’ words reflect the calm, thoughtful and premium care we aim to deliver in every visit.</p>
   <a href="https://www.google.com/maps/search/?api=1&query=Pawsh%20Pet%20Beauty%20Salon%2C%20Agias%20Glykerias%2062%2C%20Galatsi" class="reviews-inline-cta" target="_blank" rel="noopener">See all Google reviews</a>
@@ -590,17 +590,36 @@
     </div>
   </section>
 
-<section class="reviews-thankyou" aria-label="100+ Google reviews">
+<section class="section reviews-thankyou" aria-label="100+ Google reviews">
   <div class="reviews-thankyou__inner">
     <h3>100+ Google reviews</h3>
     <p>Thank you for your trust! Pawsh Pet Beauty Salon has reached 100+ Google reviews with a 5.0 rating. Your support inspires us to keep offering calm, careful and professional grooming for every pet.</p>
     <a href="https://www.google.com/maps/search/?api=1&query=Pawsh%20Pet%20Beauty%20Salon%2C%20Agias%20Glykerias%2062%2C%20Galatsi" class="hero-cta hero-cta-secondary" target="_blank" rel="noopener">See all Google reviews</a>
+    <a href="../assets/reviews/pawsh-100-axiologiseis-google-galatsi.webp" target="_blank" rel="noopener" aria-label="Open Pawsh 100 Google reviews image in larger size">
+      <img
+        src="../assets/reviews/pawsh-100-axiologiseis-google-galatsi.webp"
+        alt="Pawsh 100 Google reviews in Galatsi - dog grooming Athens"
+        class="reviews-celebration-image"
+        loading="lazy"
+      >
+    </a>
   </div>
 </section>
 
-    <section class="map">
+    <section class="section map alt" aria-labelledby="map-title">
+      <h2 id="map-title">How to find us in Galatsi</h2>
+      <p>You can find us at 62 Agias Glykerias in Galatsi, with convenient access from nearby Athens neighbourhoods.</p>
       <a class="map-link" href="https://www.google.com/maps/search/?api=1&query=%CE%91%CE%B3%CE%AF%CE%B1%CF%82+%CE%93%CE%BB%CF%85%CE%BA%CE%B5%CF%81%CE%AF%CE%B1%CF%82+62%2C+%CE%93%CE%B1%CE%BB%CE%AC%CF%84%CF%83%CE%B9+111+47%2C+%CE%95%CE%BB%CE%BB%CE%AC%CE%B4%CE%B1" target="_blank" rel="noopener">Open the address in Google Maps</a>
       <iframe src="https://www.google.com/maps?q=62+Agias+Glykerias,+Galatsi,+111+47,+Greece&output=embed" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+    </section>
+
+    <section class="section cta center" aria-labelledby="final-booking-cta-title">
+      <h2 id="final-booking-cta-title">Ready for your dog’s next grooming session?</h2>
+      <p>Book your next appointment at Pawsh Pet Grooming in just a few clicks.</p>
+      <div class="hero-cta-group">
+        <a href="https://pawshpetbeautysalon.setmore.com" class="hero-cta" target="_blank" rel="noopener">Book Appointment</a>
+        <a href="tel:+302104404084" class="hero-cta hero-cta-ghost">Call Us</a>
+      </div>
     </section>
 
 

--- a/style.css
+++ b/style.css
@@ -228,6 +228,18 @@ header nav a {
   background-color: #efe6d3;
 }
 
+.home-page .section {
+  max-width: none;
+  margin: 0;
+  padding: 4rem 1rem;
+}
+
+.home-page .section > * {
+  max-width: 960px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 section {
   padding: 4rem 1rem;
   max-width: 960px;


### PR DESCRIPTION
### Motivation
- Fix inconsistent homepage section backgrounds that produced boxed backgrounds instead of full-width bands and bring English homepage layout/UI parity with the Greek homepage. 
- Restore the missing visual in the English “100+ Google reviews” block so the EN reviews area matches the Greek equivalent.

### Description
- Applied homepage section system in `style.css` so `.home-page .section` provides full-width backgrounds while inner content stays centered using `.home-page .section > *` with `max-width: 960px`.
- Updated `en/index.html` to match Greek structure by adding `class="section"` and `alt` where appropriate for `#philosophy`, `#services`, `.areas-served`, gallery, `.faq`, `#reviews`, `.reviews-thankyou`, map and the final CTA, and moved the gallery heading into the gallery container for parity.
- Added the same celebration image used in the Greek site to the EN reviews thank-you block using the existing asset at `assets/reviews/pawsh-100-axiologiseis-google-galatsi.webp` with a correct EN-relative path (`../assets/reviews/...`) so the photo/visual now appears in EN.
- Only `en/index.html` and `style.css` were modified and no gallery JS, assets, SEO metadata, canonical, schema JSON-LD, hreflang, sitemap, robots or Open Graph tags were changed.

### Testing
- Ran repository audits and targeted searches with `rg` to confirm section IDs/classes and the presence of the added image path, which returned the updated locations successfully.
- Inspected the updated file regions with `sed`/file excerpts to verify the `section`/`alt` class additions and the inserted image element were placed correctly, and those checks passed.
- Produced a diff of the modified files to confirm only `en/index.html` and `style.css` changed and that no prohibited metadata or asset renames occurred, and the diff matched expectations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f78eeb4eb88320b159a4d407c25176)