### PR TITLE
Fix homepage gallery 5th image (swap to existing golden retriever asset)

### DIFF
--- a/index.html
+++ b/index.html
@@ -745,6 +745,17 @@
       });
     });
 
+    const gallerySlides = document.querySelectorAll('.pawsh-gallery-track .pawsh-gallery-slide img');
+    const fifthGalleryImage = gallerySlides[4];
+    if (fifthGalleryImage) {
+      fifthGalleryImage.src = 'assets/images/pet-grooming-galatsi-golden-retriever-kanapes.webp';
+      fifthGalleryImage.alt = 'περιποίηση σκύλου golden retriever στο Pawsh Γαλάτσι';
+      const fifthSlideButton = fifthGalleryImage.closest('.pawsh-gallery-slide-button');
+      if (fifthSlideButton) {
+        fifthSlideButton.setAttribute('aria-label', `Μεγέθυνση: ${fifthGalleryImage.alt}`);
+      }
+    }
+
     // Review carousel for mobile
     const reviewList = document.querySelector('.review-list');
     const prevReview = document.querySelector('.review-carousel-btn.prev');


### PR DESCRIPTION
### Motivation
- The 5th image in the homepage gallery carousel appeared visually incorrect (bad crop/aspect fit) and needed to be swapped to an image with a matching aspect and correct display under `object-fit: cover`.
- The change should be minimal and only replace the single image source while keeping carousel layout and logic unchanged.

### Description
- Added a small runtime replacement in `index.html` that targets the 5th gallery `<img>` (index 4) and updates its `src` and `alt` while preserving classes and DOM structure.
- The replacement swaps `assets/images/pet-grooming-galatsi-labrador-retriever.webp` (runtime position 5) for `assets/images/pet-grooming-galatsi-golden-retriever-kanapes.webp` and updates the corresponding button `aria-label` to match the new `alt` text.
- Only `index.html` was modified and no carousel count, CSS, JS files, or other pages (including `gallery.html` and `en/index.html`) were changed.

### Testing
- Verified the replacement asset exists with `test -f assets/images/pet-grooming-galatsi-golden-retriever-kanapes.webp` which returned success.
- Inspected the change with `git diff` and confirmed only `index.html` was modified and the diff contains the intended runtime swap snippet.
- Committed the update successfully and validated repository status with `git status` showing the single file change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79f99b4ec83208624f365069046c6)