### PR TITLE
Replace homepage Labrador gallery slide with large mixed-breed dog image

### DIFF
--- a/index.html
+++ b/index.html
@@ -759,6 +759,20 @@
       });
     }
 
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const carouselImage = document.querySelector('#gallery .pawsh-gallery-slide img[src*="pet-grooming-galatsi-labrador-retriever.webp"]');
+      if (!carouselImage) return;
+
+      carouselImage.src = 'assets/images/pet-grooming-galatsi-large-mixed-dog-sofa.webp';
+      carouselImage.alt = 'Μεγάλος ημίαιμος σκύλος μετά από grooming στο Γαλάτσι';
+
+      const triggerButton = carouselImage.closest('.pawsh-gallery-slide-button');
+      if (triggerButton) {
+        triggerButton.setAttribute('aria-label', 'Μεγέθυνση: Μεγάλος ημίαιμος σκύλος μετά από grooming στο Γαλάτσι');
+      }
+    });
+
     const backToTop = document.getElementById('back-to-top');
     if (backToTop) {
       window.addEventListener('scroll', () => {


### PR DESCRIPTION
### Motivation
- The homepage gallery contained the Labrador image `pet-grooming-galatsi-labrador-retriever.webp` which needs to be replaced in-place with an existing large mixed-breed dog image.
- The change should preserve carousel structure, ordering, and behavior while updating the visible asset and text for accessibility.

### Description
- Added a small DOM-initialization snippet to `index.html` that finds the gallery slide using the existing Labrador image source and replaces its `src` with `assets/images/pet-grooming-galatsi-large-mixed-dog-sofa.webp`.
- Updated the slide `alt` to `Μεγάλος ημίαιμος σκύλος μετά από grooming στο Γαλάτσι` and updated the slide trigger button `aria-label` to match the new alt.
- Kept the same DOM structure, classes, slide order, image count, and all gallery behavior and scripts unchanged.
- Only `index.html` was modified; `gallery.html`, `en/index.html`, `assets/js/main.js`, and other files were left intact.

### Testing
- Searched the repository to locate occurrences of the old and new image references using `rg -n "pet-grooming-galatsi-labrador-retriever|pet-grooming-galatsi-large-mixed-dog-sofa|Μεγάλος ημίαιμος σκύλος μετά από grooming στο Γαλάτσι"` and confirmed the homepage now references the new asset while the gallery page still retains the original (which was intentionally not changed). (success)
- Inspected the modified range of `index.html` with `sed`/`nl` to verify the inserted DOM-replacement snippet is present and correctly sets `src`, `alt`, and the `aria-label`. (success)
- Confirmed no other image references or files were altered by re-running targeted searches for the Labrador asset across `index.html` and `en/index.html`. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a546546083208549acad162693e7)