### PR TITLE
Compact cookie consent banner: reduce footprint and improve mobile UX

### DIFF
--- a/style.css
+++ b/style.css
@@ -1342,19 +1342,23 @@ body.pawsh-gallery-no-scroll { overflow: hidden; }
 
 .cookie-banner {
   position: fixed;
-  bottom: 1.5rem;
-  left: 50%;
-  transform: translateX(-50%);
-  width: min(640px, calc(100% - 2rem));
+  bottom: 1rem;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  width: calc(100% - 2rem);
+  max-width: 640px;
+  max-height: 40vh;
+  overflow-y: auto;
   background: rgba(6, 61, 73, 0.96);
   color: #fefaf0;
-  padding: 1.75rem;
-  border-radius: 1.25rem;
-  box-shadow: 0 22px 45px rgba(6, 61, 73, 0.35);
-  border: 2px solid #d7c9a9;
+  padding: 0.875rem 1rem;
+  border-radius: 0.875rem;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
+  border: 1px solid #d7c9a9;
   z-index: 9999;
   display: none;
-  gap: 1rem;
+  gap: 0.6rem;
 }
 
 .cookie-banner.is-visible {
@@ -1362,27 +1366,28 @@ body.pawsh-gallery-no-scroll { overflow: hidden; }
 }
 
 .cookie-banner__heading {
-  margin: 0 0 0.5rem;
-  font-size: 1.35rem;
+  margin: 0;
+  font-size: 1.05rem;
   color: #d7c9a9;
 }
 
 .cookie-banner p {
   margin: 0;
-  font-size: 1rem;
-  line-height: 1.6;
+  font-size: 0.9rem;
+  line-height: 1.4;
 }
 
 .cookie-banner__actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-top: 1rem;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
 }
 
 .cookie-banner__button {
-  flex: 1 0 auto;
-  padding: 0.75rem 1.5rem;
+  flex: 0 0 auto;
+  padding: 0.5rem 0.875rem;
+  font-size: 0.85rem;
   border-radius: 999px;
   border: none;
   font-weight: 600;
@@ -1407,6 +1412,7 @@ body.pawsh-gallery-no-scroll { overflow: hidden; }
   align-items: center;
   gap: 0.35rem;
   color: #fefaf0;
+  font-size: 0.85rem;
   font-weight: 600;
   text-decoration: underline;
 }
@@ -1434,24 +1440,24 @@ body.pawsh-gallery-no-scroll { overflow: hidden; }
 
 .cookie-banner__fine-print {
   margin: 0;
-  font-size: 0.85rem;
+  font-size: 0.78rem;
+  line-height: 1.35;
   color: rgba(254, 250, 240, 0.8);
 }
 
 @media (max-width: 640px) {
   .cookie-banner {
-    bottom: 1rem;
     width: calc(100% - 1.5rem);
-    padding: 1.5rem;
+    max-height: 35vh;
+    padding: 0.75rem;
+  }
+
+  .cookie-banner p {
+    font-size: 0.85rem;
   }
 
   .cookie-banner__actions {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .cookie-banner__button {
-    width: 100%;
+    align-items: center;
   }
 }
 


### PR DESCRIPTION
### Motivation
- The cookie consent banner was visually large and covered a substantial portion of the homepage, especially on mobile, making the UX intrusive. 
- The goal is to make the banner compact and less dominating while keeping it readable and fully functional. 

### Description
- Reduced the cookie banner footprint by updating `.cookie-banner` in `style.css` to use centered bottom positioning, constrained `max-width: 640px`, `max-height: 40vh` (desktop) and `35vh` (mobile), internal scrolling, reduced padding, smaller border-radius, and a subtler shadow. 
- Reduced heading/body/fine-print font sizes and tightened spacing for `.cookie-banner__heading`, `.cookie-banner p`, and `.cookie-banner__fine-print` to keep content readable but less prominent. 
- Adjusted action layout and button sizing (`.cookie-banner__actions`, `.cookie-banner__button`, and `.cookie-banner__link`) so controls remain tappable and wrap appropriately on small screens. 
- No JavaScript, consent logic, tracking scripts, metadata, or other files were changed; only CSS layout/styling in `style.css` was modified and the existing `.cookie-banner` selector and sub-elements are preserved. 

### Testing
- Located the banner and consent logic by searching for "cookie|consent" and confirmed the selector in `index.html` is `#cookie-banner` / `.cookie-banner`. 
- Verified the styling changes in `style.css` and confirmed visual constraints (`max-height`, padding, font-size`) were applied to limit banner coverage. 
- Inspected the banner markup and inline JS in `index.html` to confirm show/hide and storage logic were not modified and remain compatible with the updated layout. 
- Confirmed only `style.css` was modified and the change is CSS-only, preserving consent functionality (interactive buttons/links remain present and styled).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a5d56ef88320b772ade236bf532c)