### PR TITLE
Fix homepage gallery lightbox sizing and image sync

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -74,7 +74,6 @@ document.addEventListener('DOMContentLoaded', () => {
     { src: resolveGalleryPath('assets/images/pet-grooming-galatsi-akita-xalarosi.webp'), alt: 'περιποίηση σκύλου akita στο Pawsh Pet Grooming Γαλάτσι' }
   ];
 
-  const slidesData = [];
   const slides = [];
 
   galleryImages.forEach(({ src, alt }, index) => {
@@ -98,7 +97,6 @@ document.addEventListener('DOMContentLoaded', () => {
     slide.appendChild(button);
     track.appendChild(slide);
 
-    slidesData.push({ src, alt });
     slides.push({ slide, button });
   });
 
@@ -161,13 +159,22 @@ document.addEventListener('DOMContentLoaded', () => {
   let touchStartY = 0;
 
   const clampIndex = (index) => {
-    const total = slidesData.length;
+    const total = slides.length;
     return (index + total) % total;
+  };
+
+  const getSlideData = (index) => {
+    const slide = slides[clampIndex(index)];
+    const image = slide?.button.querySelector('img');
+    return {
+      src: image?.currentSrc || image?.src || '',
+      alt: image?.alt || ''
+    };
   };
 
   const showImage = (index) => {
     currentIndex = clampIndex(index);
-    const { src, alt } = slidesData[currentIndex];
+    const { src, alt } = getSlideData(currentIndex);
     lightboxImage.src = src;
     lightboxImage.alt = alt;
     lightboxCaption.textContent = alt;

--- a/index.html
+++ b/index.html
@@ -759,20 +759,6 @@
       });
     }
 
-
-    document.addEventListener('DOMContentLoaded', () => {
-      const carouselImage = document.querySelector('#gallery .pawsh-gallery-slide img[src*="pet-grooming-galatsi-labrador-retriever.webp"]');
-      if (!carouselImage) return;
-
-      carouselImage.src = 'assets/images/pet-grooming-galatsi-large-mixed-dog-sofa.webp';
-      carouselImage.alt = 'Μεγάλος ημίαιμος σκύλος μετά από grooming στο Γαλάτσι';
-
-      const triggerButton = carouselImage.closest('.pawsh-gallery-slide-button');
-      if (triggerButton) {
-        triggerButton.setAttribute('aria-label', 'Μεγέθυνση: Μεγάλος ημίαιμος σκύλος μετά από grooming στο Γαλάτσι');
-      }
-    });
-
     const backToTop = document.getElementById('back-to-top');
     if (backToTop) {
       window.addEventListener('scroll', () => {

--- a/style.css
+++ b/style.css
@@ -1308,18 +1308,34 @@ footer img.logo {
 .pawsh-gallery-lightbox {
   position: fixed;
   inset: 0;
+  width: 100vw;
+  height: 100vh;
   display: none;
   align-items: center;
   justify-content: center;
-  gap: 1rem;
   padding: 1.25rem;
-  background: rgba(3, 18, 22, 0.9);
-  z-index: 1000;
+  background: rgba(0, 0, 0, 0.85);
+  z-index: 9999;
 }
 .pawsh-gallery-lightbox[hidden] { display: none; }
 .pawsh-gallery-lightbox:not([hidden]) { display: flex; }
-.pawsh-gallery-lightbox-figure { max-width: min(92vw, 980px); margin: 0; }
-.pawsh-gallery-lightbox-image { width: 100%; max-height: 78vh; object-fit: contain; border-radius: 14px; }
+.pawsh-gallery-lightbox-figure {
+  max-width: 90vw;
+  max-height: 90vh;
+  width: min(90vw, 980px);
+  height: min(90vh, 680px);
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+.pawsh-gallery-lightbox-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 12px;
+}
 .pawsh-gallery-lightbox-caption { color: #fff; text-align: center; margin-top: 0.6rem; }
 .pawsh-gallery-lightbox-control, .pawsh-gallery-lightbox-close { cursor:pointer; }
 


### PR DESCRIPTION
### Motivation

- Fix the homepage gallery lightbox which rendered as a boxed overlay, did not let images fill the modal, and showed a mismatched image for the 5th carousel preview when opened.
- Ensure the carousel preview is the single source of truth so clicking a preview always opens the same image in the lightbox.

### Description

- Updated the lightbox CSS (`.pawsh-gallery-lightbox`, `.pawsh-gallery-lightbox-figure`, `.pawsh-gallery-lightbox-image`) to be a true fullscreen modal using `position: fixed`, `inset: 0`, `width: 100vw`, `height: 100vh`, a dark backdrop and `z-index: 9999`, constrained inner figure (`max-width: 90vw`, `max-height: 90vh`) and an image that fills its container with `width:100%`, `height:100%`, `object-fit:cover` and rounded corners.
- Reworked the gallery JS (`assets/js/main.js`) to stop using a detached image data list and instead use `getSlideData()` that reads the clicked slide's `img.currentSrc || img.src` and `img.alt`, and use that data in `showImage()`/`openLightbox()` so the preview image is the source of truth.
- Removed the homepage-only inline post-render image swap in `index.html` that was changing the 5th preview after render (this was the root cause of the preview/lightbox desync).
- Confirmed only `index.html`, `style.css`, and `assets/js/main.js` were modified and `gallery.html` and SEO-related files were left untouched.

### Testing

- Ran `node --check assets/js/main.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ac61a05c8320939a0505e784be11)