### PR TITLE
Fix gallery mobile grid to render two images per row

### DIFF
--- a/style.css
+++ b/style.css
@@ -1527,11 +1527,16 @@ body.pawsh-gallery-no-scroll { overflow: hidden; }
 
 @media (max-width: 640px) {
   .gallery-paw-bg .gallery-grid {
+    display: grid !important;
     grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
-    gap: 12px;
+    gap: 12px !important;
+    padding: 0 0.75rem;
   }
 
   .gallery-paw-bg .gallery-grid img {
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    object-fit: cover;
     border-radius: 14px;
   }
 }


### PR DESCRIPTION
### Motivation
- Mobile gallery thumbnails were rendering as a single large column instead of a compact two-up grid, making the Gallery Results page hard to use on phones. 
- The change is scoped to the gallery page grid (`.gallery-paw-bg .gallery-grid`) and must not affect the homepage carousel, gallery HTML structure, or lightbox behavior.

### Description
- Updated `style.css` to add a mobile-specific rule under `@media (max-width: 640px)` that forces a two-column grid for `.gallery-paw-bg .gallery-grid` and includes `display: grid !important`, `grid-template-columns: repeat(2, minmax(0, 1fr)) !important`, `gap: 12px !important`, and `padding: 0 0.75rem`.
- Ensured gallery images under `.gallery-paw-bg` on mobile use `width: 100%`, `aspect-ratio: 1 / 1`, and `object-fit: cover` for uniform square thumbnails with `border-radius: 14px`.
- Kept the existing `@media (max-width: 360px)` fallback to a single column when necessary.
- Scope and `!important` usage avoid touching the homepage carousel or other gallery variants; only `style.css` was modified.

### Testing
- Ran `rg -n "gallery-paw-bg|gallery-grid|@media \(max-width: 640px\)|max-width: 360px" style.css` to locate and verify mobile rules, which returned the updated locations.
- Verified the file diff shows only `style.css` changes and the new mobile grid rules are present by inspecting the diff and the file region (`nl -ba style.css | sed -n '1498,1550p'`), both succeeding.
- Confirmed that there were no other conflicting `.gallery-paw-bg` mobile rules forcing a single-column layout; generic `.gallery-grid`/`.gallery-grid img` selectors exist elsewhere but the new scoped `!important` rules override them on the gallery page.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7addb280c8320af2c3778b33ef09e)