### PR TITLE
Add accessible tabbed UI to gallery page (Αποτελέσματα / Πριν & Μετά)

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -98,9 +98,13 @@
   </div>
 
   <main class="py-8">
-    <h1 class="text-center text-3xl md:text-4xl font-semibold tracking-wide text-[#063d49] mb-8">Gallery Pawsh – Καλλωπισμός &amp; Μεταμορφώσεις</h1>
+    <h1 class="text-center text-3xl md:text-4xl font-semibold tracking-wide text-[#063d49] mb-4">Gallery Pawsh – Αποτελέσματα &amp; Πριν/Μετά</h1>
+    <div class="gallery-tabs" role="tablist" aria-label="Εναλλαγή ενότητας γκαλερί">
+      <button type="button" class="gallery-tab-button active" id="gallery-tab-results" role="tab" aria-selected="true" aria-controls="gallery-panel-results">Αποτελέσματα</button>
+      <button type="button" class="gallery-tab-button" id="gallery-tab-before-after" role="tab" aria-selected="false" aria-controls="gallery-panel-before-after">Πριν &amp; Μετά</button>
+    </div>
 
-    <section class="gallery-page-section" aria-labelledby="gallery-results-title">
+    <section class="gallery-page-section gallery-tab-panel active" id="gallery-panel-results" role="tabpanel" aria-labelledby="gallery-tab-results">
       <h2 id="gallery-results-title" class="gallery-section-title">Gallery Αποτελεσμάτων</h2>
       <p class="gallery-intro">Δες στιγμές από περιποιήσεις σκύλων στο Pawsh Pet Grooming.</p>
       <div class="gallery-grid" aria-label="Gallery σκύλων μετά τον καλλωπισμό">
@@ -144,7 +148,7 @@
       </div>
     </section>
 
-    <section class="gallery-page-section" aria-labelledby="gallery-before-after-title">
+    <section class="gallery-page-section gallery-tab-panel" id="gallery-panel-before-after" role="tabpanel" aria-labelledby="gallery-tab-before-after" hidden>
       <h2 id="gallery-before-after-title" class="gallery-section-title">Πριν &amp; Μετά</h2>
       <p class="gallery-intro">Σύγκρινε το αποτέλεσμα πριν και μετά την περιποίηση.</p>
       <div class="pawsh-compare-grid" aria-label="Σύγκριση φωτογραφιών πριν και μετά">
@@ -260,6 +264,30 @@
 
       backToTop.addEventListener('click', () => {
         window.scrollTo({ top: 0, behavior: 'smooth' });
+      });
+    }
+
+    const tabButtons = Array.from(document.querySelectorAll('.gallery-tab-button'));
+    const tabPanels = Array.from(document.querySelectorAll('.gallery-tab-panel'));
+    if (tabButtons.length && tabPanels.length) {
+      const setActiveTab = (tabId) => {
+        tabButtons.forEach((button) => {
+          const isActive = button.id === tabId;
+          const panelId = button.getAttribute('aria-controls');
+          const panel = panelId ? document.getElementById(panelId) : null;
+
+          button.classList.toggle('active', isActive);
+          button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+
+          if (panel) {
+            panel.classList.toggle('active', isActive);
+            panel.hidden = !isActive;
+          }
+        });
+      };
+
+      tabButtons.forEach((button) => {
+        button.addEventListener('click', () => setActiveTab(button.id));
       });
     }
 

--- a/style.css
+++ b/style.css
@@ -949,6 +949,44 @@ footer img.logo {
   margin-bottom: 2.5rem;
 }
 
+.gallery-tabs {
+  max-width: 1280px;
+  margin: 0 auto 1.5rem;
+  padding: 0 1rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.gallery-tab-button {
+  appearance: none;
+  border: 1px solid rgba(6, 61, 73, 0.24);
+  background: #fff;
+  color: #063d49;
+  border-radius: 999px;
+  padding: 0.6rem 1.2rem;
+  font-weight: 700;
+  line-height: 1.2;
+  transition: all 0.2s ease;
+}
+
+.gallery-tab-button.active {
+  background: #063d49;
+  color: #f3ede0;
+  border-color: #063d49;
+  box-shadow: 0 10px 22px rgba(6, 61, 73, 0.2);
+}
+
+.gallery-tab-button:focus-visible {
+  outline: 3px solid rgba(6, 61, 73, 0.35);
+  outline-offset: 2px;
+}
+
+.gallery-tab-panel:not(.active) {
+  display: none;
+}
+
 .gallery-section-title {
   max-width: 1180px;
   margin: 0 auto 0.5rem;
@@ -1526,6 +1564,18 @@ body.pawsh-gallery-no-scroll { overflow: hidden; }
 }
 
 @media (max-width: 640px) {
+  .gallery-tabs {
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+  }
+
+  .gallery-tab-button {
+    flex: 1 1 calc(50% - 0.25rem);
+    min-height: 44px;
+    padding: 0.65rem 0.8rem;
+    text-align: center;
+  }
+
   .gallery-paw-bg .gallery-grid {
     display: grid !important;
     grid-template-columns: repeat(2, minmax(0, 1fr)) !important;


### PR DESCRIPTION
### Motivation
- The gallery page contained both “Αποτελέσματα” and “Πριν & Μετά” content inline which made the page long and less focused. 
- Provide a compact, mobile-friendly tabbed interface so users can switch between the two sections while preserving SEO and existing functionality.

### Description
- Replaced the page H1 with the required text `Gallery Pawsh – Αποτελέσματα & Πριν/Μετά` and added a tab row under the title with buttons using `gallery-tabs`, `gallery-tab-button`, and `gallery-tab-button.active` classes. 
- Wrapped the existing gallery and before/after sections in tab panels using `gallery-tab-panel` and applied `hidden`/`.active` handling so both sections remain in the DOM for SEO and crawlability. 
- Implemented lightweight vanilla JS in `gallery.html` to toggle `aria-selected`, `hidden`, and active classes when tabs are clicked, with no external libraries and no gallery markup generation by JS. 
- Added pill-style tab visuals and responsive tap-friendly rules to `style.css`, and preserved all existing image markup, lightbox wiring (`.gallery-grid img, .pawsh-compare img`) and before/after slider logic so existing behavior remains functional. 
- Files modified: `gallery.html` and `style.css`.

### Testing
- Verified file-level changes and content with repository scans and file reads using `rg --files | head -n 200` and `sed -n '1,260p' gallery.html` and `sed -n '260,520p' gallery.html`, which showed the new tab markup and JS present. 
- Confirmed CSS additions for `.gallery-tabs`, `.gallery-tab-button`, `.gallery-tab-panel` and responsive rules with `rg -n "gallery-page-section|gallery-grid|pawsh-compare|gallery-section-title|gallery-intro|gallery-lightbox" style.css` and by inspecting relevant `style.css` ranges. 
- Checked that the lightbox selector and before/after slider code remain unchanged and still reference `.gallery-grid img` and `.pawsh-compare img` by inspecting the JS blocks, confirming the lightbox initialization code still applies to both panels. 
- Note: visual/manual browser verification (tab click visuals, lightbox interaction on each tab, and slider dragging on hidden→visible panels) was not executed in this CLI environment and should be validated in a browser as a final step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0de65bc73883208e02d42c5b5c0937)