### PR TITLE
Add 5 new Πριν & Μετά grooming cards to gallery tab panel

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -188,6 +188,36 @@
         <input type="range" class="pc-slider" min="0" max="100" value="50" aria-label="Σύγκριση πριν και μετά – Καλλωπισμός 6">
         <div class="pc-handle"><span></span></div>
       </div>
+      <div class="pawsh-compare">
+        <img class="pc-after" src="assets/images/before-after-maltese-white-fluffy-after.webp" alt="Λευκό Maltese μετά από grooming στο Pawsh Γαλάτσι" loading="lazy">
+        <img class="pc-before" src="assets/images/before-after-maltese-white-before.webp" alt="Maltese πριν από grooming στο Pawsh Γαλάτσι" loading="lazy">
+        <input type="range" class="pc-slider" min="0" max="100" value="50" aria-label="Σύγκριση πριν και μετά – Καλλωπισμός 7">
+        <div class="pc-handle"><span></span></div>
+      </div>
+      <div class="pawsh-compare">
+        <img class="pc-after" src="assets/images/before-after-mini-schnauzer-after.webp" alt="Mini Schnauzer μετά από grooming στο Pawsh Γαλάτσι" loading="lazy">
+        <img class="pc-before" src="assets/images/before-after-mini-schnauzer-before.webp" alt="Mini Schnauzer πριν από grooming στο Pawsh Γαλάτσι" loading="lazy">
+        <input type="range" class="pc-slider" min="0" max="100" value="50" aria-label="Σύγκριση πριν και μετά – Καλλωπισμός 8">
+        <div class="pc-handle"><span></span></div>
+      </div>
+      <div class="pawsh-compare">
+        <img class="pc-after" src="assets/images/before-after-shih-tzu-blue-bandana-after.webp" alt="Shih Tzu με μπλε μπαντάνα μετά από grooming στο Pawsh Γαλάτσι" loading="lazy">
+        <img class="pc-before" src="assets/images/before-after-shih-tzu-green-table-before.webp" alt="Shih Tzu πριν από grooming στο Pawsh Γαλάτσι" loading="lazy">
+        <input type="range" class="pc-slider" min="0" max="100" value="50" aria-label="Σύγκριση πριν και μετά – Καλλωπισμός 9">
+        <div class="pc-handle"><span></span></div>
+      </div>
+      <div class="pawsh-compare">
+        <img class="pc-after" src="assets/images/before-after-yorkshire-pink-flower-after.webp" alt="Yorkshire Terrier με ροζ λουλούδι μετά από grooming στο Pawsh Γαλάτσι" loading="lazy">
+        <img class="pc-before" src="assets/images/before-after-yorkshire-before.webp" alt="Yorkshire Terrier πριν από grooming στο Pawsh Γαλάτσι" loading="lazy">
+        <input type="range" class="pc-slider" min="0" max="100" value="50" aria-label="Σύγκριση πριν και μετά – Καλλωπισμός 10">
+        <div class="pc-handle"><span></span></div>
+      </div>
+      <div class="pawsh-compare">
+        <img class="pc-after" src="assets/images/before-after-shih-tzu-skyblue-bandana-after.webp" alt="Shih Tzu με γαλάζια μπαντάνα μετά από grooming στο Pawsh Γαλάτσι" loading="lazy">
+        <img class="pc-before" src="assets/images/before-after-shih-tzu-longhair-before.webp" alt="Shih Tzu με μακρύ τρίχωμα πριν από grooming στο Pawsh Γαλάτσι" loading="lazy">
+        <input type="range" class="pc-slider" min="0" max="100" value="50" aria-label="Σύγκριση πριν και μετά – Καλλωπισμός 11">
+        <div class="pc-handle"><span></span></div>
+      </div>
       </div>
     </section>
     <div class="gallery-bottom-cta">


### PR DESCRIPTION
### Motivation
- Expand the existing “Πριν & Μετά” gallery with five additional grooming examples so users can compare more before/after results. 
- Ensure additions reuse the current interactive comparison pattern without changing layout, styling, or gallery behaviors.

### Description
- Appended five new `div.pawsh-compare` cards to `gallery.html` inside the `#gallery-panel-before-after` panel, using the same `pc-after`/`pc-before`/`pc-slider`/`pc-handle` structure and `loading="lazy"` pattern as existing entries. 
- Each new card references the provided paths under `assets/images/` and includes the supplied Greek alt texts for both before and after images. 
- No other HTML sections, SEO/meta/schema, JS for tabs or lightbox, styling, or the `Αποτελέσματα` tab were modified. 
- The modified file is `gallery.html` only. 

### Testing
- Located the before/after tab and lines with `rg` to confirm target insertion point, which matched the `#gallery-panel-before-after` region. 
- Inspected the change region with `nl -ba gallery.html | sed -n` and reviewed the `git diff -- gallery.html` output to confirm the five `pawsh-compare` blocks were appended after the existing entries. 
- Verified with `git status --short` that only `gallery.html` changed and no other files were modified. 
- Ran a file-existence check for the ten referenced images under `assets/images/` and found the image files are currently missing from the repository (image presence check: FAILED).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0def71260483209a3bb7f897c1111b)