### PR TITLE
Use homepage Pawsh logo in QR landing and point booking CTA to Setmore

### DIFF
--- a/scan/index.html
+++ b/scan/index.html
@@ -23,7 +23,7 @@
   <main class="scan-page" aria-labelledby="scan-title">
     <header class="scan-hero">
       <a class="scan-logo-link" href="https://pawsh.gr/" aria-label="Pawsh αρχική σελίδα">
-        <img src="/logo/logo.png" alt="Pawsh Pet Beauty Salon logo" class="scan-logo" width="128" height="128">
+        <img src="/logo/logo.png" alt="Pawsh Pet Beauty Salon logo" class="scan-logo" width="1162" height="215">
       </a>
       <p class="scan-eyebrow">Pawsh</p>
       <p class="scan-subtitle">PET BEAUTY SALON</p>
@@ -32,7 +32,7 @@
     </header>
 
     <section class="scan-actions" aria-label="Βασικές ενέργειες Pawsh">
-      <a class="scan-button scan-button--primary" href="tel:+302104404084">
+      <a class="scan-button scan-button--primary" href="https://pawshpetbeautysalon.setmore.com/" target="_blank" rel="noopener noreferrer">
         <span>Κλείστε ραντεβού</span>
         <span aria-hidden="true">☎</span>
       </a>


### PR DESCRIPTION
### Motivation
- Ensure the QR landing page displays the exact same Pawsh homepage logo asset with correct intrinsic proportions and descriptive alt text.  
- Make the primary “Κλείστε ραντεβού” CTA open the official Pawsh Setmore booking page while keeping the telephone contact accessible elsewhere on the page.

### Description
- Updated `scan/index.html` to reuse the homepage logo asset at `/logo/logo.png` in the header and set the image intrinsic dimensions to the actual asset proportions (`width="1162" height="215"`) while retaining the descriptive `alt` and existing `.scan-logo` class.  
- Replaced the primary appointment button href from `tel:+302104404084` to `https://pawshpetbeautysalon.setmore.com/` and added `target="_blank" rel="noopener noreferrer"`, keeping the visible text exactly `Κλείστε ραντεβού`.  
- Left the telephone link inside the business information card unchanged as `href="tel:+302104404084"`.  
- No styling, button order, SEO settings, other links, or the original logo file were modified.

### Testing
- Confirmed the logo file exists at `/logo/logo.png` and inspected its pixel dimensions (1162×215) and applied those dimensions to the image tag; check passed.  
- Ran an automated content check (`python3` script) that verified the primary button uses the Setmore URL with `target="_blank" rel="noopener noreferrer"`, the business info phone link remains `tel:+302104404084`, the header image references `/logo/logo.png`, and no placeholder/stitch references remain; all checks returned true.  
- Manual HTML snippet inspection of `scan/index.html` confirmed the changed lines reflect the intended updates and that the telephone info card still contains the clickable phone link; inspection passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b1b829b4c8320be7770066484b28b)