### PR TITLE
Add downloadable Pawsh vCard and 'Αποθήκευση επαφής' button to scan page

### DIFF
--- a/scan/index.html
+++ b/scan/index.html
@@ -40,6 +40,10 @@
         <span>Γράψτε μια κριτική στο Google</span>
         <span aria-hidden="true">★</span>
       </a>
+      <a class="scan-button" href="/scan/pawsh.vcf" download="Pawsh-Pet-Beauty-Salon.vcf" aria-label="Αποθήκευση επαφής Pawsh Pet Beauty Salon">
+        <span>Αποθήκευση επαφής</span>
+        <span aria-hidden="true">☏</span>
+      </a>
       <a class="scan-button" href="https://pawsh.gr/" target="_blank" rel="noopener noreferrer">
         <span>Επισκεφθείτε το site μας</span>
         <span aria-hidden="true">↗</span>

--- a/scan/pawsh.vcf
+++ b/scan/pawsh.vcf
@@ -1,0 +1,10 @@
+BEGIN:VCARD
+VERSION:3.0
+FN:Pawsh Pet Beauty Salon
+ORG:Pawsh Pet Beauty Salon
+TEL;TYPE=WORK,VOICE:+302104404084
+ADR;TYPE=WORK:;;Αγίας Γλυκερίας 62;Γαλάτσι;;11147;Ελλάδα
+URL:https://pawsh.gr/
+X-SOCIALPROFILE;TYPE=instagram:https://www.instagram.com/pawsh_pet_salon/
+NOTE:Online ραντεβού: https://pawshpetbeautysalon.setmore.com/
+END:VCARD


### PR DESCRIPTION
### Motivation
- Provide an easy way for users to save Pawsh contact details from the scan landing page as a vCard compatible with iPhone and Android. 
- Use vCard version `3.0` with UTF-8 encoding to preserve Greek characters and broad device compatibility. 
- Place the download action in the requested sequence without changing existing URLs, styling, SEO, or other site behavior.

### Description
- Added a UTF-8 vCard file at `scan/pawsh.vcf` containing the requested fields (VERSION:3.0, `FN`, `ORG`, `TEL;TYPE=WORK,VOICE:+302104404084`, `ADR` with Greek address, `URL`, Instagram `X-SOCIALPROFILE`, and the Setmore note) and no email entry.
- Inserted a download button into `scan/index.html` immediately after the Google review action with: `href="/scan/pawsh.vcf"`, `download="Pawsh-Pet-Beauty-Salon.vcf"`, an `aria-label`, visible label `Αποθήκευση επαφής`, and a contact icon character to match existing button styling.
- Preserved the remaining button order and all existing links, logo, canonical URL, SEO metadata, `noindex, follow` directive, and styling from the original page.
- Did not modify any unrelated site files or external URLs (Setmore, Google Review, Maps, etc.).

### Testing
- Ran Python assertions to verify vCard content (version, phone number, URL, Setmore note, Greek address) and they passed.
- Ran a Python HTML parse to assert button order and `download` link attributes, and the checks passed.
- Served the site with `python3 -m http.server` and used `curl` to download `/scan/pawsh.vcf`, then compared the download to the source file, and the check passed confirming UTF-8 decoding and Greek characters.
- Verified `scan` button sizing via a CSS assertion (`min-height: 3.35rem`) and ran `npm test` (`node --check server.js`); both checks passed (npm produced a non-blocking warning).
- Attempted a Playwright mobile screenshot to validate tappable size visually, but Playwright could not be installed in this environment (registry returned `403 Forbidden`), so that visual screenshot step was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42c83ae6c08320846834ec21b11023)