### PR TITLE
Refine desktop header award badge styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -2153,7 +2153,22 @@ footer a {
   gap: 0.5rem;
 }
 
-.header-award-badge,
+.header-award-badge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 10px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(218, 194, 137, 0.28);
+  border-radius: 10px;
+  box-shadow: 0 3px 12px rgba(0, 0, 0, 0.12);
+  line-height: 0;
+  transition:
+    background-color 0.25s ease,
+    transform 0.25s ease,
+    box-shadow 0.25s ease;
+}
+
 .award-badge-link {
   display: inline-flex;
   align-items: center;
@@ -2162,7 +2177,12 @@ footer a {
 }
 
 .header-award-badge:hover,
-.header-award-badge:focus-visible,
+.header-award-badge:focus-visible {
+  background: rgba(255, 255, 255, 0.17);
+  transform: translateY(-1px);
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.16);
+}
+
 .award-badge-link:hover,
 .award-badge-link:focus-visible {
   opacity: 0.88;
@@ -2179,6 +2199,7 @@ footer a {
   display: block;
   width: clamp(145px, 12vw, 165px);
   height: auto;
+  filter: brightness(1.08);
 }
 
 .award-section {


### PR DESCRIPTION
### Motivation
- Make the desktop header award badge subtly brighter and more visible against the dark green header while preserving the premium look and layout.

### Description
- Updated the shared desktop selector `.header-award-badge` to add a subtle semi-transparent light background, a soft gold-toned border, a small radius, a restrained shadow, and a smooth transition by adding `padding: 6px 10px`, `background: rgba(255,255,255,0.12)`, `border: 1px solid rgba(218,194,137,0.28)`, `border-radius: 10px`, `box-shadow: 0 3px 12px rgba(0,0,0,0.12)`, `line-height: 0`, and `transition: background-color 0.25s ease, transform 0.25s ease, box-shadow 0.25s ease` to `.header-award-badge`.
- Added a restrained hover/focus effect on `.header-award-badge` that uses `background: rgba(255,255,255,0.17)`, `transform: translateY(-1px)`, and `box-shadow: 0 5px 15px rgba(0,0,0,0.16)` so the interaction is subtle and not visually dominant.
- Increased the badge image brightness only by adding `filter: brightness(1.08)` to `.header-award-badge img` while preserving the existing `width: clamp(145px, 12vw, 165px)` and aspect ratio.
- Preserved existing related rules and layout by leaving `.award-badge-link`/`.award-badge-image` selectors unchanged and keeping the mobile hiding rule `@media (max-width: 899px) { .header-award-badge { display: none; } }`.

### Testing
- Ran `npm test` (the `test` script runs `node --check server.js`) and it completed successfully with no syntax errors.
- Ran `git diff --check` and it reported no whitespace or diff-check issues.
- Performed static verification confirming the header row/logo sizing was unchanged, the badge image width declaration (`width: clamp(145px, 12vw, 165px)`) remained single and unchanged, the badge wrapper received only `padding: 6px 10px` (12px vertical total), and the badge remains hidden below 900px via `@media (max-width: 899px)`.
- All automated checks and static validations passed.

Exact CSS changes made:
- Modified selector: `.header-award-badge` — added `display: flex; align-items: center; justify-content: center; padding: 6px 10px; background: rgba(255,255,255,0.12); border: 1px solid rgba(218,194,137,0.28); border-radius: 10px; box-shadow: 0 3px 12px rgba(0,0,0,0.12); line-height: 0; transition: background-color 0.25s ease, transform 0.25s ease, box-shadow 0.25s ease;`.
- Modified selector: `.header-award-badge:hover, .header-award-badge:focus-visible` — set `background: rgba(255,255,255,0.17); transform: translateY(-1px); box-shadow: 0 5px 15px rgba(0,0,0,0.16);`.
- Modified selector: `.header-award-badge img` — added `filter: brightness(1.08);` while keeping `width: clamp(145px, 12vw, 165px); height: auto;`.
- Kept `.award-badge-link` and `.award-badge-image` rules unchanged and preserved `@media (max-width: 899px) { .header-award-badge { display: none; } }`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a554fecbb0c8320846af671de135ebb)