### PR TITLE
Fix award badge layouts and /scan/ hero symmetry

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -99,7 +99,7 @@
           <a href="index.html" class="mx-auto"><img src="../logo/logo.png" alt="Pawsh logo" class="h-16"></a>
           <div class="desktop-header-actions absolute right-4 flex items-center space-x-2">
             <a href="https://www.aetoitisperipoiisiskatikidion.eu/profile-2741-pawsh" class="header-award-badge" target="_blank" rel="noopener noreferrer" aria-label="View the Pawsh award from Aetoi Pet Grooming Awards">
-              <img src="https://www.aetoitisperipoiisiskatikidion.eu/images/medals/2741/laureat300_black_gr.png" alt="Pawsh - Aetoi Pet Grooming Award">
+              <img src="https://www.aetoitisperipoiisiskatikidion.eu/images/medals/2741/laureat300_gold_gr.png" width="300" height="75" alt="Pawsh - Aetoi Pet Grooming Award">
             </a>
             <a href="https://www.facebook.com/profile.php?id=61578078265850" class="radial-icon" aria-label="Facebook" target="_blank" rel="noopener">
               <img src="../logo/facebooklogo.svg" alt="Facebook Icon">
@@ -599,7 +599,7 @@
     <h2 id="award-heading">Award-winning pet grooming</h2>
     <p>Pawsh has been distinguished by the Aetoi Pet Grooming Awards, reflecting the trust and appreciation of our clients.</p>
     <a href="https://www.aetoitisperipoiisiskatikidion.eu/profile-2741-pawsh" class="award-badge-link" target="_blank" rel="noopener noreferrer" aria-label="View the Pawsh award from Aetoi Pet Grooming Awards">
-      <img src="https://www.aetoitisperipoiisiskatikidion.eu/images/medals/2741/laureat300_black_gr.png" alt="Pawsh - Aetoi Pet Grooming Award" class="award-badge-image" loading="lazy" decoding="async">
+      <img src="https://www.aetoitisperipoiisiskatikidion.eu/images/medals/2741/laureat110_black_gr.png" alt="Pawsh - Aetoi Pet Grooming Award" class="award-badge-image" width="110" height="110" loading="lazy" decoding="async">
     </a>
   </div>
 </section>

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
           <a href="index.html" class="mx-auto"><img src="logo/logo.png" alt="Pawsh logo" class="h-16"></a>
           <div class="desktop-header-actions absolute right-4 flex items-center space-x-2">
             <a href="https://www.aetoitisperipoiisiskatikidion.eu/profile-2741-pawsh" class="header-award-badge" target="_blank" rel="noopener noreferrer" aria-label="Δείτε τη διάκριση του Pawsh στους Αετούς της Περιποίησης Κατοικιδίων">
-              <img src="https://www.aetoitisperipoiisiskatikidion.eu/images/medals/2741/laureat300_black_gr.png" alt="Pawsh - Διάκριση στους Αετούς της Περιποίησης Κατοικιδίων">
+              <img src="https://www.aetoitisperipoiisiskatikidion.eu/images/medals/2741/laureat300_gold_gr.png" width="300" height="75" alt="Pawsh - Διάκριση στους Αετούς της Περιποίησης Κατοικιδίων">
             </a>
             <a href="https://www.facebook.com/profile.php?id=61578078265850" class="radial-icon" aria-label="Facebook" target="_blank" rel="noopener">
               <img src="logo/facebooklogo.svg" alt="Facebook Icon">
@@ -626,7 +626,7 @@
     <h2 id="award-heading">Βραβευμένη περιποίηση κατοικιδίων</h2>
     <p>Το Pawsh διακρίθηκε στους Αετούς της Περιποίησης Κατοικιδίων, επιβεβαιώνοντας την εμπιστοσύνη και την αγάπη των πελατών μας.</p>
     <a href="https://www.aetoitisperipoiisiskatikidion.eu/profile-2741-pawsh" class="award-badge-link" target="_blank" rel="noopener noreferrer" aria-label="Δείτε τη διάκριση του Pawsh στους Αετούς της Περιποίησης Κατοικιδίων">
-      <img src="https://www.aetoitisperipoiisiskatikidion.eu/images/medals/2741/laureat300_black_gr.png" alt="Pawsh - Διάκριση στους Αετούς της Περιποίησης Κατοικιδίων" class="award-badge-image" loading="lazy" decoding="async">
+      <img src="https://www.aetoitisperipoiisiskatikidion.eu/images/medals/2741/laureat110_black_gr.png" alt="Pawsh - Διάκριση στους Αετούς της Περιποίησης Κατοικιδίων" class="award-badge-image" width="110" height="110" loading="lazy" decoding="async">
     </a>
   </div>
 </section>

--- a/scan/index.html
+++ b/scan/index.html
@@ -24,7 +24,7 @@
     <header class="scan-hero">
       <div class="scan-hero-layout">
         <a class="scan-award scan-award--left" href="https://www.aetoitisperipoiisiskatikidion.eu/profile-2741-pawsh" target="_blank" rel="noopener noreferrer" aria-label="Δείτε τη διάκριση του Pawsh στους Αετούς της Περιποίησης Κατοικιδίων">
-          <img src="https://www.aetoitisperipoiisiskatikidion.eu/images/medals/2741/laureat110_gold_gr.png" alt="" width="110" height="110" decoding="async">
+          <img src="https://www.aetoitisperipoiisiskatikidion.eu/images/medals/2741/laureat110_black_gr.png" alt="Pawsh - Διάκριση στους Αετούς της Περιποίησης Κατοικιδίων" width="110" height="110" decoding="async">
         </a>
 
         <div class="scan-hero-content">
@@ -38,7 +38,7 @@
         </div>
 
         <a class="scan-award scan-award--right" href="https://www.aetoitisperipoiisiskatikidion.eu/profile-2741-pawsh" target="_blank" rel="noopener noreferrer" aria-label="Δείτε τη διάκριση του Pawsh στους Αετούς της Περιποίησης Κατοικιδίων">
-          <img src="https://www.aetoitisperipoiisiskatikidion.eu/images/medals/2741/laureat110_gold_gr.png" alt="" width="110" height="110" decoding="async">
+          <img src="https://www.aetoitisperipoiisiskatikidion.eu/images/medals/2741/laureat110_black_gr.png" alt="Pawsh - Διάκριση στους Αετούς της Περιποίησης Κατοικιδίων" width="110" height="110" decoding="async">
         </a>
       </div>
     </header>

--- a/scan/scan.css
+++ b/scan/scan.css
@@ -54,27 +54,32 @@ a:focus-visible {
   flex-direction: column;
   align-items: center;
   text-align: center;
-  padding: 0.65rem 0 1.05rem;
+  padding: 0.65rem 0 0;
 }
 
 
 .scan-hero-layout {
-  display: grid;
-  justify-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  margin-inline: auto;
 }
 
 .scan-hero-content {
+  order: 1;
   display: flex;
   min-width: 0;
   flex-direction: column;
   align-items: center;
+  text-align: center;
 }
 
 .scan-award {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  margin: 1rem 0 0.1rem;
+  line-height: 0;
   text-decoration: none;
   transition: transform 160ms ease, opacity 160ms ease;
 }
@@ -84,13 +89,25 @@ a:focus-visible {
   opacity: 0.9;
 }
 
+.scan-award:focus-visible {
+  outline: 3px solid var(--gold);
+  outline-offset: 5px;
+}
+
 .scan-award img {
-  width: clamp(5.625rem, 24vw, 6.25rem);
-  height: clamp(5.625rem, 24vw, 6.25rem);
+  display: block;
+  width: 90px;
+  height: 90px;
   object-fit: contain;
 }
 
 .scan-award--left { display: none; }
+
+.scan-award--right {
+  order: 2;
+  margin-top: 16px;
+  margin-bottom: 22px;
+}
 
 .scan-logo-link {
   display: inline-flex;
@@ -267,20 +284,26 @@ a:focus-visible {
     width: min(100%, 44rem);
   }
 
-  .scan-hero-layout {
-    grid-template-columns: clamp(5.3rem, 12vw, 6.875rem) minmax(18.5rem, 1fr) clamp(5.3rem, 12vw, 6.875rem);
-    align-items: center;
-    gap: clamp(1.5rem, 5vw, 4rem);
-    width: 100%;
+  .scan-hero {
+    padding-bottom: 1.7rem;
   }
 
-  .scan-award {
+  .scan-hero-layout {
+    display: grid;
+    grid-template-columns: 90px minmax(280px, 400px) 90px;
+    justify-content: center;
+    align-items: center;
+    column-gap: 24px;
+  }
+
+  .scan-award,
+  .scan-award--right {
     margin: 0;
   }
 
   .scan-award img {
-    width: clamp(5.3rem, 12vw, 6.875rem);
-    height: clamp(5.3rem, 12vw, 6.875rem);
+    width: 90px;
+    height: 90px;
   }
 
   .scan-award--left { display: inline-flex; }
@@ -291,6 +314,22 @@ a:focus-visible {
     width: min(100%, 28rem);
     margin-right: auto;
     margin-left: auto;
+  }
+}
+
+@media (min-width: 901px) {
+  .scan-page {
+    width: min(100%, 52rem);
+  }
+
+  .scan-hero-layout {
+    grid-template-columns: 110px minmax(300px, 420px) 110px;
+    column-gap: clamp(32px, 6vw, 90px);
+  }
+
+  .scan-award img {
+    width: 110px;
+    height: 110px;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -2157,16 +2157,9 @@ footer a {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 6px 10px;
-  background: rgba(255, 255, 255, 0.12);
-  border: 1px solid rgba(218, 194, 137, 0.28);
-  border-radius: 10px;
-  box-shadow: 0 3px 12px rgba(0, 0, 0, 0.12);
+  filter: drop-shadow(0 2px 5px rgba(0, 0, 0, 0.18));
   line-height: 0;
-  transition:
-    background-color 0.25s ease,
-    transform 0.25s ease,
-    box-shadow 0.25s ease;
+  transition: transform 0.25s ease, opacity 0.25s ease, filter 0.25s ease;
 }
 
 .award-badge-link {
@@ -2178,9 +2171,9 @@ footer a {
 
 .header-award-badge:hover,
 .header-award-badge:focus-visible {
-  background: rgba(255, 255, 255, 0.17);
+  opacity: 0.92;
   transform: translateY(-1px);
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.16);
+  filter: drop-shadow(0 3px 7px rgba(0, 0, 0, 0.22));
 }
 
 .award-badge-link:hover,
@@ -2199,7 +2192,7 @@ footer a {
   display: block;
   width: clamp(145px, 12vw, 165px);
   height: auto;
-  filter: brightness(1.08);
+  object-fit: contain;
 }
 
 .award-section {
@@ -2232,21 +2225,29 @@ footer a {
 }
 
 .award-badge-link {
-  margin-top: 1.35rem;
-  max-width: 300px;
-  width: min(100%, 300px);
+  margin-top: 1.15rem;
+  width: 110px;
+  max-width: 110px;
+  line-height: 0;
 }
 
 .award-badge-image {
   display: block;
-  width: 100%;
-  max-width: 300px;
-  height: auto;
+  width: 110px;
+  height: 110px;
+  object-fit: contain;
 }
 
 @media (max-width: 899px) {
   .header-award-badge {
     display: none;
+  }
+}
+
+@media (max-width: 700px) {
+  .award-section .award-badge-image {
+    width: 90px;
+    height: 90px;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Replace inconsistent/incorrect award badges across the site with the official assets and ensure correct placement, sizing and accessibility. 
- Fix the `/scan/` hero where badges were stacked vertically and restore the intended left-center-right symmetry on desktop/tablet while keeping a single centered badge on mobile. 
- Keep the existing header, logo, navigation, buttons and overall visual identity unchanged while removing obsolete badge styling that generated visual noise. 

### Description
- Replaced the desktop header badge in both Greek and English pages with the official horizontal gold image (`https://www.aetoitisperipoiisiskatikidion.eu/images/medals/2741/laureat300_gold_gr.png`) and added intrinsic `width=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55592df3788320915b66a8f92a2a1b)