### PR TITLE
Add temporary summer closure announcement banner

### DIFF
--- a/about.html
+++ b/about.html
@@ -28,6 +28,12 @@
   <meta property="og:locale" content="el_GR">
 </head>
 <body>
+    <aside class="summer-closure-banner" data-summer-closure-banner hidden aria-label="Ανακοίνωση καλοκαιρινών διακοπών">
+      <p class="summer-closure-banner__message"><span class="summer-closure-banner__title">🐾 Μικρές καλοκαιρινές διακοπές!</span> Το Pawsh θα παραμείνει κλειστό 11–24 Αυγούστου. Επιστρέφουμε την Τρίτη 25 Αυγούστου και σας περιμένουμε ξανά! ☀️🐶</p>
+      <button class="summer-closure-banner__close" type="button" data-summer-closure-close aria-label="Κλείσιμο ανακοίνωσης">×</button>
+    </aside>
+    <script src="assets/js/summer-closure-banner.js"></script>
+
   <h2 class="sr-only">Η Αλεξάνδρα και το Όραμά της για το Pet Grooming</h2>
   <p class="sr-only">Το Pawsh δημιουργήθηκε με αγάπη για τα ζώα από την Αλεξάνδρα, πρώην chef και νυν επαγγελματία groomer με σπουδές και εμπειρία στον χώρο.</p>
   <header class="bg-[#063d49] text-white">

--- a/assets/js/summer-closure-banner.js
+++ b/assets/js/summer-closure-banner.js
@@ -1,0 +1,35 @@
+(function () {
+  'use strict';
+
+  const banner = document.querySelector('[data-summer-closure-banner]');
+  if (!banner) return;
+
+  const dismissalKey = 'pawsh_summer_closure_banner_dismissed';
+  const expiry = new Date(2026, 7, 25, 0, 0, 0);
+  let dismissed = false;
+
+  try {
+    dismissed = sessionStorage.getItem(dismissalKey) === 'true';
+  } catch (error) {
+    // The notice still works when storage is unavailable.
+  }
+
+  if (new Date() >= expiry || dismissed) {
+    banner.remove();
+    return;
+  }
+
+  banner.hidden = false;
+
+  const closeButton = banner.querySelector('[data-summer-closure-close]');
+  if (!closeButton) return;
+
+  closeButton.addEventListener('click', function () {
+    try {
+      sessionStorage.setItem(dismissalKey, 'true');
+    } catch (error) {
+      // Dismiss for this page even when storage is unavailable.
+    }
+    banner.remove();
+  });
+}());

--- a/contact.html
+++ b/contact.html
@@ -28,6 +28,12 @@
   <meta property="og:locale" content="el_GR">
 </head>
 <body>
+    <aside class="summer-closure-banner" data-summer-closure-banner hidden aria-label="Ανακοίνωση καλοκαιρινών διακοπών">
+      <p class="summer-closure-banner__message"><span class="summer-closure-banner__title">🐾 Μικρές καλοκαιρινές διακοπές!</span> Το Pawsh θα παραμείνει κλειστό 11–24 Αυγούστου. Επιστρέφουμε την Τρίτη 25 Αυγούστου και σας περιμένουμε ξανά! ☀️🐶</p>
+      <button class="summer-closure-banner__close" type="button" data-summer-closure-close aria-label="Κλείσιμο ανακοίνωσης">×</button>
+    </aside>
+    <script src="assets/js/summer-closure-banner.js"></script>
+
   <header class="bg-[#063d49] text-white">
     <div class="hidden md:block">
       <div class="flex items-center justify-center relative py-2 border-b border-[#d7c9a9]">

--- a/en/about.html
+++ b/en/about.html
@@ -28,6 +28,12 @@
   <meta property="og:locale" content="en_US">
 </head>
 <body>
+    <aside class="summer-closure-banner" data-summer-closure-banner hidden aria-label="Summer closure announcement">
+      <p class="summer-closure-banner__message"><span class="summer-closure-banner__title">🐾 Short summer break!</span> Pawsh will remain closed from 11–24 August. We reopen on Tuesday, 25 August and look forward to welcoming you back! ☀️🐶</p>
+      <button class="summer-closure-banner__close" type="button" data-summer-closure-close aria-label="Close announcement">×</button>
+    </aside>
+    <script src="../assets/js/summer-closure-banner.js"></script>
+
   <h2 class="sr-only">Alexandra and the vision behind Pawsh dog grooming</h2>
   <p class="sr-only">Pawsh was created out of genuine love for animals by Alexandra, a professional groomer with training, experience and a positive approach.</p>
   <header class="bg-[#063d49] text-white">

--- a/en/contact.html
+++ b/en/contact.html
@@ -28,6 +28,12 @@
   <meta property="og:locale" content="en_US">
 </head>
 <body>
+    <aside class="summer-closure-banner" data-summer-closure-banner hidden aria-label="Summer closure announcement">
+      <p class="summer-closure-banner__message"><span class="summer-closure-banner__title">🐾 Short summer break!</span> Pawsh will remain closed from 11–24 August. We reopen on Tuesday, 25 August and look forward to welcoming you back! ☀️🐶</p>
+      <button class="summer-closure-banner__close" type="button" data-summer-closure-close aria-label="Close announcement">×</button>
+    </aside>
+    <script src="../assets/js/summer-closure-banner.js"></script>
+
   <header class="bg-[#063d49] text-white">
     <div class="hidden md:block">
       <div class="flex items-center justify-center relative py-2 border-b border-[#d7c9a9]">

--- a/en/gallery.html
+++ b/en/gallery.html
@@ -28,6 +28,12 @@
   <meta property="og:locale" content="en_US">
 </head>
 <body class="gallery-paw-bg">
+    <aside class="summer-closure-banner" data-summer-closure-banner hidden aria-label="Summer closure announcement">
+      <p class="summer-closure-banner__message"><span class="summer-closure-banner__title">🐾 Short summer break!</span> Pawsh will remain closed from 11–24 August. We reopen on Tuesday, 25 August and look forward to welcoming you back! ☀️🐶</p>
+      <button class="summer-closure-banner__close" type="button" data-summer-closure-close aria-label="Close announcement">×</button>
+    </aside>
+    <script src="../assets/js/summer-closure-banner.js"></script>
+
   <h2 class="sr-only">See our salon and our happy dogs</h2>
   <p class="sr-only">A closer look at the results Pawsh delivers through thoughtful, calm grooming and beautiful real-life transformations.</p>
   <header class="bg-[#063d49] text-white">

--- a/en/grooming-galatsi.html
+++ b/en/grooming-galatsi.html
@@ -22,6 +22,12 @@
   <meta property="og:locale" content="en_US">
 </head>
 <body>
+    <aside class="summer-closure-banner" data-summer-closure-banner hidden aria-label="Summer closure announcement">
+      <p class="summer-closure-banner__message"><span class="summer-closure-banner__title">🐾 Short summer break!</span> Pawsh will remain closed from 11–24 August. We reopen on Tuesday, 25 August and look forward to welcoming you back! ☀️🐶</p>
+      <button class="summer-closure-banner__close" type="button" data-summer-closure-close aria-label="Close announcement">×</button>
+    </aside>
+    <script src="../assets/js/summer-closure-banner.js"></script>
+
   <header class="bg-[#063d49] text-white">
     <div class="hidden md:block"><div class="flex items-center justify-center relative py-2 border-b border-[#d7c9a9]"><a href="index.html" class="mx-auto"><img src="../logo/logo.png" alt="Pawsh logo" class="h-16"></a><div class="absolute right-4 flex space-x-2"><a href="https://www.facebook.com/profile.php?id=61578078265850" class="radial-icon" aria-label="Facebook" target="_blank" rel="noopener"><img src="../logo/facebooklogo.svg" alt="Facebook Icon"></a><a href="https://www.instagram.com/pawsh_pet_salon/" class="radial-icon" aria-label="Instagram" target="_blank" rel="noopener"><img src="../logo/instagramlogo.svg" alt="Instagram Icon"></a></div></div><nav class="flex justify-center space-x-6 py-2"><a href="index.html" class="text-[#d7c9a9] hover:underline">Home</a><a href="about.html" class="text-[#d7c9a9] hover:underline">The Story</a><a href="services.html" class="text-[#d7c9a9] hover:underline">Services</a><a href="grooming-galatsi.html" class="text-[#d7c9a9] hover:underline">Galatsi Grooming</a><a href="gallery.html" class="text-[#d7c9a9] hover:underline">Gallery</a><a href="contact.html" class="text-[#d7c9a9] hover:underline">Contact</a><div class="text-[#d7c9a9]" aria-label="Language switcher"><a href="../grooming-galatsi.html" class="hover:underline">GR</a> | <span aria-current="true">EN</span></div></nav></div>
     <div class="mobile-header md:hidden"><button id="menu-button" class="menu-button mobile-header__menu flex h-12 w-12 items-center justify-center focus:outline-none" aria-label="Open menu" aria-expanded="false">

--- a/en/index.html
+++ b/en/index.html
@@ -90,6 +90,12 @@
   <meta property="og:locale" content="en_US">
 </head>
   <body>
+    <aside class="summer-closure-banner" data-summer-closure-banner hidden aria-label="Summer closure announcement">
+      <p class="summer-closure-banner__message"><span class="summer-closure-banner__title">🐾 Short summer break!</span> Pawsh will remain closed from 11–24 August. We reopen on Tuesday, 25 August and look forward to welcoming you back! ☀️🐶</p>
+      <button class="summer-closure-banner__close" type="button" data-summer-closure-close aria-label="Close announcement">×</button>
+    </aside>
+    <script src="../assets/js/summer-closure-banner.js"></script>
+
     <h2 class="sr-only">Dog Grooming in Galatsi with Safety, Care & a Positive Approach</h2>
     <p class="sr-only">At Pawsh Pet Beauty Salon, we offer professional dog grooming and pet grooming services in Galatsi for families across Galatsi, Kypseli, Patisia, Psychiko and Filothei, always focusing on comfort, wellbeing and beautiful results.</p>
     <header class="bg-[#063d49] text-white">

--- a/en/services.html
+++ b/en/services.html
@@ -22,6 +22,12 @@
   <meta property="og:locale" content="en_US">
 </head>
 <body>
+    <aside class="summer-closure-banner" data-summer-closure-banner hidden aria-label="Summer closure announcement">
+      <p class="summer-closure-banner__message"><span class="summer-closure-banner__title">🐾 Short summer break!</span> Pawsh will remain closed from 11–24 August. We reopen on Tuesday, 25 August and look forward to welcoming you back! ☀️🐶</p>
+      <button class="summer-closure-banner__close" type="button" data-summer-closure-close aria-label="Close announcement">×</button>
+    </aside>
+    <script src="../assets/js/summer-closure-banner.js"></script>
+
   <header class="bg-[#063d49] text-white">
     <div class="hidden md:block">
       <div class="flex items-center justify-center relative py-2 border-b border-[#d7c9a9]">

--- a/gallery.html
+++ b/gallery.html
@@ -28,6 +28,12 @@
   <meta property="og:locale" content="el_GR">
 </head>
 <body class="gallery-paw-bg">
+    <aside class="summer-closure-banner" data-summer-closure-banner hidden aria-label="Ανακοίνωση καλοκαιρινών διακοπών">
+      <p class="summer-closure-banner__message"><span class="summer-closure-banner__title">🐾 Μικρές καλοκαιρινές διακοπές!</span> Το Pawsh θα παραμείνει κλειστό 11–24 Αυγούστου. Επιστρέφουμε την Τρίτη 25 Αυγούστου και σας περιμένουμε ξανά! ☀️🐶</p>
+      <button class="summer-closure-banner__close" type="button" data-summer-closure-close aria-label="Κλείσιμο ανακοίνωσης">×</button>
+    </aside>
+    <script src="assets/js/summer-closure-banner.js"></script>
+
   <h2 class="sr-only">Δείτε τον Χώρο μας και τα Χαρούμενα Σκυλάκια μας</h2>
   <p class="sr-only">Μια ματιά στις υπηρεσίες και το αποτέλεσμα που προσφέρει το Pawsh, μέσα από φωτογραφίες γεμάτες χαρά και φροντίδα.</p>
   <header class="bg-[#063d49] text-white">

--- a/grooming-galatsi.html
+++ b/grooming-galatsi.html
@@ -22,6 +22,12 @@
   <meta property="og:locale" content="el_GR">
 </head>
 <body>
+    <aside class="summer-closure-banner" data-summer-closure-banner hidden aria-label="Ανακοίνωση καλοκαιρινών διακοπών">
+      <p class="summer-closure-banner__message"><span class="summer-closure-banner__title">🐾 Μικρές καλοκαιρινές διακοπές!</span> Το Pawsh θα παραμείνει κλειστό 11–24 Αυγούστου. Επιστρέφουμε την Τρίτη 25 Αυγούστου και σας περιμένουμε ξανά! ☀️🐶</p>
+      <button class="summer-closure-banner__close" type="button" data-summer-closure-close aria-label="Κλείσιμο ανακοίνωσης">×</button>
+    </aside>
+    <script src="assets/js/summer-closure-banner.js"></script>
+
   <header class="bg-[#063d49] text-white">
     <div class="hidden md:block"><div class="flex items-center justify-center relative py-2 border-b border-[#d7c9a9]"><a href="index.html" class="mx-auto"><img src="logo/logo.png" alt="Pawsh logo" class="h-16"></a><div class="absolute right-4 flex space-x-2"><a href="https://www.facebook.com/profile.php?id=61578078265850" class="radial-icon" aria-label="Facebook" target="_blank" rel="noopener"><img src="logo/facebooklogo.svg" alt="Facebook Icon"></a><a href="https://www.instagram.com/pawsh_pet_salon/" class="radial-icon" aria-label="Instagram" target="_blank" rel="noopener"><img src="logo/instagramlogo.svg" alt="Instagram Icon"></a></div></div><nav class="flex justify-center space-x-6 py-2">
           <a href="index.html" class="text-[#d7c9a9] hover:underline">Αρχική</a>

--- a/index.html
+++ b/index.html
@@ -90,6 +90,12 @@
   <meta property="og:locale" content="el_GR">
 </head>
   <body class="home-page">
+    <aside class="summer-closure-banner" data-summer-closure-banner hidden aria-label="Ανακοίνωση καλοκαιρινών διακοπών">
+      <p class="summer-closure-banner__message"><span class="summer-closure-banner__title">🐾 Μικρές καλοκαιρινές διακοπές!</span> Το Pawsh θα παραμείνει κλειστό 11–24 Αυγούστου. Επιστρέφουμε την Τρίτη 25 Αυγούστου και σας περιμένουμε ξανά! ☀️🐶</p>
+      <button class="summer-closure-banner__close" type="button" data-summer-closure-close aria-label="Κλείσιμο ανακοίνωσης">×</button>
+    </aside>
+    <script src="assets/js/summer-closure-banner.js"></script>
+
     <h2 class="sr-only">Καλλωπισμός Σκύλων στο Γαλάτσι με Ασφάλεια, Αγάπη & Θετική Προσέγγιση</h2>
     <p class="sr-only">Στο Pawsh Pet Beauty Salon προσφέρουμε επαγγελματικές υπηρεσίες pet grooming, κομμωτηρίου σκύλων και καλλωπισμού σκύλων στο Γαλάτσι. Εξυπηρετούμε κηδεμόνες από Γαλάτσι, Κυψέλη, Πατήσια, Ψυχικό και Φιλοθέη, με στόχο τη χαρά και την ευεξία κάθε κατοικιδίου.</p>
     <header class="bg-[#063d49] text-white">

--- a/services.html
+++ b/services.html
@@ -22,6 +22,12 @@
   <meta property="og:locale" content="el_GR">
 </head>
 <body>
+    <aside class="summer-closure-banner" data-summer-closure-banner hidden aria-label="Ανακοίνωση καλοκαιρινών διακοπών">
+      <p class="summer-closure-banner__message"><span class="summer-closure-banner__title">🐾 Μικρές καλοκαιρινές διακοπές!</span> Το Pawsh θα παραμείνει κλειστό 11–24 Αυγούστου. Επιστρέφουμε την Τρίτη 25 Αυγούστου και σας περιμένουμε ξανά! ☀️🐶</p>
+      <button class="summer-closure-banner__close" type="button" data-summer-closure-close aria-label="Κλείσιμο ανακοίνωσης">×</button>
+    </aside>
+    <script src="assets/js/summer-closure-banner.js"></script>
+
   <header class="bg-[#063d49] text-white">
     <div class="hidden md:block">
       <div class="flex items-center justify-center relative py-2 border-b border-[#d7c9a9]">

--- a/style.css
+++ b/style.css
@@ -17,6 +17,83 @@ a {
   text-decoration: none;
 }
 
+.summer-closure-banner[hidden] {
+  display: none;
+}
+
+.summer-closure-banner {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 3rem;
+  padding: 0.5rem 3.5rem 0.5rem 1rem;
+  box-sizing: border-box;
+  background: var(--main-bg);
+  color: var(--accent);
+  text-align: center;
+}
+
+.summer-closure-banner__message {
+  margin: 0;
+  max-width: 70rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.summer-closure-banner__title {
+  font-weight: 700;
+}
+
+.summer-closure-banner__close {
+  position: absolute;
+  top: 50%;
+  right: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  transform: translateY(-50%);
+}
+
+.summer-closure-banner__close:hover,
+.summer-closure-banner__close:focus-visible {
+  background: rgba(6, 61, 73, 0.1);
+}
+
+.summer-closure-banner__close:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+@media (max-width: 640px) {
+  .summer-closure-banner {
+    padding-top: 0.625rem;
+    padding-bottom: 0.625rem;
+    padding-left: 0.75rem;
+  }
+
+  .summer-closure-banner__message {
+    font-size: 0.8125rem;
+  }
+
+  .summer-closure-banner__title {
+    display: block;
+  }
+}
+
 .radial-icon {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
### Motivation
- Add a lightweight, branded, and accessible temporary announcement banner to inform visitors the store is closed 11–24 August and reopens 25 August, applied to all main Greek and English pages.
- Keep the site design, navigation, and SEO/head content unchanged while ensuring the banner is slim, mobile-friendly, and does not introduce new libraries or images.

### Description
- Files updated: added `assets/js/summer-closure-banner.js`, updated `style.css`, and injected localized banner markup + per-page script include into `index.html`, `about.html`, `services.html`, `grooming-galatsi.html`, `gallery.html`, `contact.html` and their English counterparts under `en/` (12 HTML files total). 
- Exact banner markup added above each header (Greek pages):
  `<aside class="summer-closure-banner" data-summer-closure-banner hidden aria-label="Ανακοίνωση καλοκαιρινών διακοπών"><p class="summer-closure-banner__message"><span class="summer-closure-banner__title">🐾 Μικρές καλοκαιρινές διακοπές!</span> Το Pawsh θα παραμείνει κλειστό 11–24 Αυγούστου. Επιστρέφουμε την Τρίτη 25 Αυγούστου και σας περιμένουμε ξανά! ☀️🐶</p><button class="summer-closure-banner__close" type="button" data-summer-closure-close aria-label="Κλείσιμο ανακοίνωσης">×</button></aside>` and (English pages):
  `<aside class="summer-closure-banner" data-summer-closure-banner hidden aria-label="Summer closure announcement"><p class="summer-closure-banner__message"><span class="summer-closure-banner__title">🐾 Short summer break!</span> Pawsh will remain closed from 11–24 August. We reopen on Tuesday, 25 August and look forward to welcoming you back! ☀️🐶</p><button class="summer-closure-banner__close" type="button" data-summer-closure-close aria-label="Close announcement">×</button></aside>`.
- CSS changes (in `style.css`): added `.summer-closure-banner`, `.summer-closure-banner__message`, `.summer-closure-banner__title`, `.summer-closure-banner__close`, a hidden-state rule `.summer-closure-banner[hidden] { display: none; }`, and responsive tweaks to ensure small, centered, non-intrusive styling using existing Pawsh variables `--main-bg` (#d7c9a9) and `--accent` (#063d49). 
- JS behavior (in `assets/js/summer-closure-banner.js`): lightweight vanilla script that looks for `[data-summer-closure-banner]`, reads session dismissal from `sessionStorage` key `pawsh_summer_closure_banner_dismissed`, computes expiry with `new Date(2026, 7, 25, 0, 0, 0)` (local time), removes the banner if expired or dismissed, otherwise unhides the banner and sets sessionStorage to `'true'` on close; the per-page `<script src=".../summer-closure-banner.js"></script>` is included immediately after the banner markup so layout shifts occur naturally. 
- Accessibility and UX: close button provides `aria-label="Κλείσιμο ανακοίνωσης"` on Greek pages and `aria-label="Close announcement"` on English pages, uses a 44px-ish tap target, focus-visible outlines and hover states, and removal is done by DOM `remove()` so the header naturally shifts down without overlap.
- SEO & layout safety: no changes were made to document <head> content, meta, structured data, canonical/hreflang/sitemap/robots, or navigation structure, and the banner is a normal-flow element placed above the header to avoid layout overlap or breaking mobile header controls.

### Testing
- Ran `npm test` (`node --check server.js`) which succeeded. 
- Static HTML validation (Python) across the 12 updated pages confirmed localized banner markup is present, initially `hidden`, placed before the first `<header>`, contains the correct localized text, and the close button `aria-label` matches language. 
- JS behavior validation (Node/VM tests) confirmed the banner shows before expiry, the close button removes the banner and writes the session key, session dismissal is honored for the visit, and the banner is automatically removed on or after `2026-08-25 00:00` local time. 
- Ran `git diff --check` and a byte-for-byte comparison of each updated document `<head>` against the original HEAD to verify no SEO/head changes; both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7cb8deb1d08320aec07b5f343b1a38)